### PR TITLE
Fix ecco bug issue #3

### DIFF
--- a/notebooks/Persian_GPT2_Visualization.ipynb
+++ b/notebooks/Persian_GPT2_Visualization.ipynb
@@ -3,15 +3,1980 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Persian GPT2 - Visualization.ipynb",
+      "name": "Copy of Persian GPT2 - Visualization.ipynb",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "name": "python3",
       "display_name": "Python 3"
     },
-    "accelerator": "GPU"
+    "accelerator": "GPU",
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "be73e6748a974382a156c9e95490b46e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_2ddcf6e28e2241bdb21802ad363bfea7",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_71ba37954f09424991023ad74ba9172e",
+              "IPY_MODEL_1dd1d0dde5fe40898bba3f527a89da9a"
+            ]
+          }
+        },
+        "2ddcf6e28e2241bdb21802ad363bfea7": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "71ba37954f09424991023ad74ba9172e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_6ca0eb97d4cb42ebae665dd5f5b46e97",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 808,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 808,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_3ed83ba0e0e541ab984947e94ad5b374"
+          }
+        },
+        "1dd1d0dde5fe40898bba3f527a89da9a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_26ebfcc6e56e4cf6bcb99cbb799cf483",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 808/808 [00:11&lt;00:00, 67.7B/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_87bb5fb348f24f40a0c99558dfd8cd99"
+          }
+        },
+        "6ca0eb97d4cb42ebae665dd5f5b46e97": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "3ed83ba0e0e541ab984947e94ad5b374": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "26ebfcc6e56e4cf6bcb99cbb799cf483": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "87bb5fb348f24f40a0c99558dfd8cd99": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "031597c17594449f982485c3ba422f9b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_3c2a9b9104574c29832ad8098db90b81",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_5c7652a7379d473bb6cc4eb7dd64e50b",
+              "IPY_MODEL_f2b6aa9a22b54284ae29537c4fc5ec9d"
+            ]
+          }
+        },
+        "3c2a9b9104574c29832ad8098db90b81": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "5c7652a7379d473bb6cc4eb7dd64e50b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_480311b14c114cc191b12b33dc748786",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 1159342,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 1159342,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_1790cc757f724d078b2746ea3d130d09"
+          }
+        },
+        "f2b6aa9a22b54284ae29537c4fc5ec9d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_959e85890a0c41d7a7676638a035de27",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 1.16M/1.16M [00:11&lt;00:00, 97.8kB/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_90329f499cf04b40bc6c1b2e95ab41ae"
+          }
+        },
+        "480311b14c114cc191b12b33dc748786": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "1790cc757f724d078b2746ea3d130d09": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "959e85890a0c41d7a7676638a035de27": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "90329f499cf04b40bc6c1b2e95ab41ae": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "370c7e72f78244a981c8a68b4b9e3160": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_dca6b0336da34aa89bb3177d39526679",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_06f0348f1c374754a94283f94cce5fca",
+              "IPY_MODEL_5616945986e4427fa98da46ff40a1e87"
+            ]
+          }
+        },
+        "dca6b0336da34aa89bb3177d39526679": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "06f0348f1c374754a94283f94cce5fca": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_4b94e4203f1d4c7e9990e44a325942be",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 875476,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 875476,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_24b95e93409f40e39cedcf148f28daf4"
+          }
+        },
+        "5616945986e4427fa98da46ff40a1e87": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_ababcfd2aed64d868a0fc74abbbd00dd",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 875k/875k [00:00&lt;00:00, 4.82MB/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_0998a3aaecf946639692e2d74edf0084"
+          }
+        },
+        "4b94e4203f1d4c7e9990e44a325942be": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "24b95e93409f40e39cedcf148f28daf4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "ababcfd2aed64d868a0fc74abbbd00dd": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "0998a3aaecf946639692e2d74edf0084": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "4cfb92d87d204313bb5da1e5ab74eccd": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_0c1b0e486abc44668c082eb913c25c63",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_d981249259b1425cb215c0c2752fc620",
+              "IPY_MODEL_49dee5c2cd34473f98335ec351c5268d"
+            ]
+          }
+        },
+        "0c1b0e486abc44668c082eb913c25c63": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "d981249259b1425cb215c0c2752fc620": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_20219e63af9648d59455dda680ef0bf3",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 2748949,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 2748949,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_ef609f3ed234444fb4bd27a559328bee"
+          }
+        },
+        "49dee5c2cd34473f98335ec351c5268d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_115e9dd0ef004780ae9dfc089800203c",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 2.75M/2.75M [00:11&lt;00:00, 237kB/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_0196d3c57e424dcfaaa94af9148e7dfb"
+          }
+        },
+        "20219e63af9648d59455dda680ef0bf3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "ef609f3ed234444fb4bd27a559328bee": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "115e9dd0ef004780ae9dfc089800203c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "0196d3c57e424dcfaaa94af9148e7dfb": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "8f1077550e0448fda8444c572cef3fcf": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_63bb39a4dab44e33a149bf82be6a846c",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_73c3fb9a321346938e1c2c10ca02e672",
+              "IPY_MODEL_df10ee7a118e4f7d882ad3356aac327a"
+            ]
+          }
+        },
+        "63bb39a4dab44e33a149bf82be6a846c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "73c3fb9a321346938e1c2c10ca02e672": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_d29ee997f122496a8daf33f2a0cd7beb",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 14,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 14,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_0d0cbf5ecaef4bbb83e513e6cc0d7ac6"
+          }
+        },
+        "df10ee7a118e4f7d882ad3356aac327a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_c3cedc9f748649448d92c5d3e4a0d9fe",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 14.0/14.0 [00:00&lt;00:00, 80.7B/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_8305df5a25d445afa16472d7ffeaedc3"
+          }
+        },
+        "d29ee997f122496a8daf33f2a0cd7beb": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "0d0cbf5ecaef4bbb83e513e6cc0d7ac6": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "c3cedc9f748649448d92c5d3e4a0d9fe": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "8305df5a25d445afa16472d7ffeaedc3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "a3b392af274a443aac1490b6d279d4f4": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_5f6f564c175d4a03a8787069cb108ecb",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_e76e3ea3c5724e2885fe200902f7effb",
+              "IPY_MODEL_0dbe77b478da4da08efa9133a8d9b1dc"
+            ]
+          }
+        },
+        "5f6f564c175d4a03a8787069cb108ecb": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "e76e3ea3c5724e2885fe200902f7effb": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_95a7b1e042ea429fa5f97c5b3a4f9bbc",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 104,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 104,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_2760873751b14db581428076c5bde76b"
+          }
+        },
+        "0dbe77b478da4da08efa9133a8d9b1dc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_af668931ac5f41b5bbfd7ab953880bf1",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 104/104 [00:00&lt;00:00, 1.10kB/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_ac71d2ac97ff464abd4a4cb6890491f8"
+          }
+        },
+        "95a7b1e042ea429fa5f97c5b3a4f9bbc": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "2760873751b14db581428076c5bde76b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "af668931ac5f41b5bbfd7ab953880bf1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "ac71d2ac97ff464abd4a4cb6890491f8": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "5cf2c4e6005b46589210042a50cf543c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_3e9bf0626b2a4c21aa6d0208eefceab5",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_c61a15c8d1e8412fa72d8f3dd044d13d",
+              "IPY_MODEL_d79ef945553d4c36a67a1ca45b056571"
+            ]
+          }
+        },
+        "3e9bf0626b2a4c21aa6d0208eefceab5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "c61a15c8d1e8412fa72d8f3dd044d13d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_e3ce4e6ba3b441fbad6dc1b5666d9a21",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 728,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 728,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_cd8a85b24e004410a7fab6d4658bc75e"
+          }
+        },
+        "d79ef945553d4c36a67a1ca45b056571": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_c5a8e262f8504ee9ac2e9132ae6280d9",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 728/728 [00:11&lt;00:00, 64.6B/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_2b4c319801fa47c5988d58567702eb52"
+          }
+        },
+        "e3ce4e6ba3b441fbad6dc1b5666d9a21": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "cd8a85b24e004410a7fab6d4658bc75e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "c5a8e262f8504ee9ac2e9132ae6280d9": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "2b4c319801fa47c5988d58567702eb52": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "0635cc54c5bc45ffa664f68a2f321d04": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_view_name": "HBoxView",
+            "_dom_classes": [],
+            "_model_name": "HBoxModel",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "box_style": "",
+            "layout": "IPY_MODEL_7d908b0bd7954b9cb39e8ff33743a114",
+            "_model_module": "@jupyter-widgets/controls",
+            "children": [
+              "IPY_MODEL_b282533eaf984dd09157a53850b4547e",
+              "IPY_MODEL_2909bfffc6a74cd9bd55df463daa6b6f"
+            ]
+          }
+        },
+        "7d908b0bd7954b9cb39e8ff33743a114": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "b282533eaf984dd09157a53850b4547e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "state": {
+            "_view_name": "ProgressView",
+            "style": "IPY_MODEL_4cb572ee18054115b82dd750509801d7",
+            "_dom_classes": [],
+            "description": "Downloading: 100%",
+            "_model_name": "FloatProgressModel",
+            "bar_style": "success",
+            "max": 485044198,
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": 485044198,
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "orientation": "horizontal",
+            "min": 0,
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_b1c9e4beb3e7451f9cb971669ed6087d"
+          }
+        },
+        "2909bfffc6a74cd9bd55df463daa6b6f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_view_name": "HTMLView",
+            "style": "IPY_MODEL_4f8c43a299de4368bbec21d766b1d72d",
+            "_dom_classes": [],
+            "description": "",
+            "_model_name": "HTMLModel",
+            "placeholder": "​",
+            "_view_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "value": " 485M/485M [00:10&lt;00:00, 47.3MB/s]",
+            "_view_count": null,
+            "_view_module_version": "1.5.0",
+            "description_tooltip": null,
+            "_model_module": "@jupyter-widgets/controls",
+            "layout": "IPY_MODEL_64206db3e6964e1fbbda7175065e6df8"
+          }
+        },
+        "4cb572ee18054115b82dd750509801d7": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "ProgressStyleModel",
+            "description_width": "initial",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "bar_color": null,
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "b1c9e4beb3e7451f9cb971669ed6087d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        },
+        "4f8c43a299de4368bbec21d766b1d72d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_view_name": "StyleView",
+            "_model_name": "DescriptionStyleModel",
+            "description_width": "",
+            "_view_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.5.0",
+            "_view_count": null,
+            "_view_module_version": "1.2.0",
+            "_model_module": "@jupyter-widgets/controls"
+          }
+        },
+        "64206db3e6964e1fbbda7175065e6df8": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_view_name": "LayoutView",
+            "grid_template_rows": null,
+            "right": null,
+            "justify_content": null,
+            "_view_module": "@jupyter-widgets/base",
+            "overflow": null,
+            "_model_module_version": "1.2.0",
+            "_view_count": null,
+            "flex_flow": null,
+            "width": null,
+            "min_width": null,
+            "border": null,
+            "align_items": null,
+            "bottom": null,
+            "_model_module": "@jupyter-widgets/base",
+            "top": null,
+            "grid_column": null,
+            "overflow_y": null,
+            "overflow_x": null,
+            "grid_auto_flow": null,
+            "grid_area": null,
+            "grid_template_columns": null,
+            "flex": null,
+            "_model_name": "LayoutModel",
+            "justify_items": null,
+            "grid_row": null,
+            "max_height": null,
+            "align_content": null,
+            "visibility": null,
+            "align_self": null,
+            "height": null,
+            "min_height": null,
+            "padding": null,
+            "grid_auto_rows": null,
+            "grid_gap": null,
+            "max_width": null,
+            "order": null,
+            "_view_module_version": "1.2.0",
+            "grid_template_areas": null,
+            "object_position": null,
+            "object_fit": null,
+            "grid_auto_columns": null,
+            "margin": null,
+            "display": null,
+            "left": null
+          }
+        }
+      }
+    }
   },
   "cells": [
     {
@@ -21,21 +1986,17 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "sUpL07IDptrs",
-        "outputId": "030566d9-1c59-4334-c72f-7c8c95e398c8"
+        "outputId": "6f8ec2e7-95b6-48f9-cff8-a2691898ee71"
       },
       "source": [
-        "!pip install -qU ecco"
+        "!pip install pyyaml"
       ],
       "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "\u001b[K     |████████████████████████████████| 1.8MB 13.9MB/s \n",
-            "\u001b[K     |████████████████████████████████| 22.2MB 54.2MB/s \n",
-            "\u001b[K     |████████████████████████████████| 3.2MB 41.0MB/s \n",
-            "\u001b[K     |████████████████████████████████| 890kB 37.5MB/s \n",
-            "\u001b[?25h  Building wheel for sacremoses (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+            "Requirement already satisfied: pyyaml in /usr/local/lib/python3.7/dist-packages (3.13)\n"
           ],
           "name": "stdout"
         }
@@ -44,15 +2005,327 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "fWBXT90ZqA41"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "-lB9nKG037bq",
+        "outputId": "90171df0-896e-421c-b7b0-ea674e788754"
+      },
+      "source": [
+        "import yaml\n",
+        "\n",
+        "!git clone https://github.com/jalammar/ecco.git\n",
+        "\n",
+        "with open('/content/ecco/src/ecco/model-config.yaml') as fy:\n",
+        "    info = yaml.load(fy)\n",
+        "\n",
+        "info[\"HooshvareLab/gpt2-fa\"] = {\n",
+        "    \"activations\": [\"mlp\\\\.c_proj\"],\n",
+        "    \"embedding\": \"transformer.wte.weight\"\n",
+        "}\n",
+        "\n",
+        "with open('/content/ecco/src/ecco/model-config.yaml', \"w\") as fy:\n",
+        "    yaml.dump(info, fy)\n",
+        "\n",
+        "\n",
+        "%cd /content/ecco\n",
+        "!pip install -q ./\n",
+        "%cd /content/"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'ecco'...\n",
+            "remote: Enumerating objects: 18, done.\u001b[K\n",
+            "remote: Counting objects: 100% (18/18), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (13/13), done.\u001b[K\n",
+            "remote: Total 1076 (delta 5), reused 13 (delta 3), pack-reused 1058\u001b[K\n",
+            "Receiving objects: 100% (1076/1076), 2.08 MiB | 26.60 MiB/s, done.\n",
+            "Resolving deltas: 100% (581/581), done.\n",
+            "/content/ecco\n",
+            "\u001b[K     |████████████████████████████████| 2.0MB 23.7MB/s \n",
+            "\u001b[K     |████████████████████████████████| 22.3MB 1.7MB/s \n",
+            "\u001b[K     |████████████████████████████████| 645kB 49.7MB/s \n",
+            "\u001b[K     |████████████████████████████████| 3.2MB 45.4MB/s \n",
+            "\u001b[K     |████████████████████████████████| 890kB 34.8MB/s \n",
+            "\u001b[?25h  Building wheel for ecco (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Building wheel for sacremoses (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "/content\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "fWBXT90ZqA41",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 415,
+          "referenced_widgets": [
+            "be73e6748a974382a156c9e95490b46e",
+            "2ddcf6e28e2241bdb21802ad363bfea7",
+            "71ba37954f09424991023ad74ba9172e",
+            "1dd1d0dde5fe40898bba3f527a89da9a",
+            "6ca0eb97d4cb42ebae665dd5f5b46e97",
+            "3ed83ba0e0e541ab984947e94ad5b374",
+            "26ebfcc6e56e4cf6bcb99cbb799cf483",
+            "87bb5fb348f24f40a0c99558dfd8cd99",
+            "031597c17594449f982485c3ba422f9b",
+            "3c2a9b9104574c29832ad8098db90b81",
+            "5c7652a7379d473bb6cc4eb7dd64e50b",
+            "f2b6aa9a22b54284ae29537c4fc5ec9d",
+            "480311b14c114cc191b12b33dc748786",
+            "1790cc757f724d078b2746ea3d130d09",
+            "959e85890a0c41d7a7676638a035de27",
+            "90329f499cf04b40bc6c1b2e95ab41ae",
+            "370c7e72f78244a981c8a68b4b9e3160",
+            "dca6b0336da34aa89bb3177d39526679",
+            "06f0348f1c374754a94283f94cce5fca",
+            "5616945986e4427fa98da46ff40a1e87",
+            "4b94e4203f1d4c7e9990e44a325942be",
+            "24b95e93409f40e39cedcf148f28daf4",
+            "ababcfd2aed64d868a0fc74abbbd00dd",
+            "0998a3aaecf946639692e2d74edf0084",
+            "4cfb92d87d204313bb5da1e5ab74eccd",
+            "0c1b0e486abc44668c082eb913c25c63",
+            "d981249259b1425cb215c0c2752fc620",
+            "49dee5c2cd34473f98335ec351c5268d",
+            "20219e63af9648d59455dda680ef0bf3",
+            "ef609f3ed234444fb4bd27a559328bee",
+            "115e9dd0ef004780ae9dfc089800203c",
+            "0196d3c57e424dcfaaa94af9148e7dfb",
+            "8f1077550e0448fda8444c572cef3fcf",
+            "63bb39a4dab44e33a149bf82be6a846c",
+            "73c3fb9a321346938e1c2c10ca02e672",
+            "df10ee7a118e4f7d882ad3356aac327a",
+            "d29ee997f122496a8daf33f2a0cd7beb",
+            "0d0cbf5ecaef4bbb83e513e6cc0d7ac6",
+            "c3cedc9f748649448d92c5d3e4a0d9fe",
+            "8305df5a25d445afa16472d7ffeaedc3",
+            "a3b392af274a443aac1490b6d279d4f4",
+            "5f6f564c175d4a03a8787069cb108ecb",
+            "e76e3ea3c5724e2885fe200902f7effb",
+            "0dbe77b478da4da08efa9133a8d9b1dc",
+            "95a7b1e042ea429fa5f97c5b3a4f9bbc",
+            "2760873751b14db581428076c5bde76b",
+            "af668931ac5f41b5bbfd7ab953880bf1",
+            "ac71d2ac97ff464abd4a4cb6890491f8",
+            "5cf2c4e6005b46589210042a50cf543c",
+            "3e9bf0626b2a4c21aa6d0208eefceab5",
+            "c61a15c8d1e8412fa72d8f3dd044d13d",
+            "d79ef945553d4c36a67a1ca45b056571",
+            "e3ce4e6ba3b441fbad6dc1b5666d9a21",
+            "cd8a85b24e004410a7fab6d4658bc75e",
+            "c5a8e262f8504ee9ac2e9132ae6280d9",
+            "2b4c319801fa47c5988d58567702eb52",
+            "0635cc54c5bc45ffa664f68a2f321d04",
+            "7d908b0bd7954b9cb39e8ff33743a114",
+            "b282533eaf984dd09157a53850b4547e",
+            "2909bfffc6a74cd9bd55df463daa6b6f",
+            "4cb572ee18054115b82dd750509801d7",
+            "b1c9e4beb3e7451f9cb971669ed6087d",
+            "4f8c43a299de4368bbec21d766b1d72d",
+            "64206db3e6964e1fbbda7175065e6df8"
+          ]
+        },
+        "outputId": "3e0adacb-5e2e-4b7d-94e2-2b4240f940da"
       },
       "source": [
         "import ecco\n",
         "\n",
         "lm = ecco.from_pretrained('HooshvareLab/gpt2-fa')"
       ],
-      "execution_count": 25,
-      "outputs": []
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "be73e6748a974382a156c9e95490b46e",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=808.0, style=ProgressStyle(description_…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "031597c17594449f982485c3ba422f9b",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=1159342.0, style=ProgressStyle(descript…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "370c7e72f78244a981c8a68b4b9e3160",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=875476.0, style=ProgressStyle(descripti…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4cfb92d87d204313bb5da1e5ab74eccd",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=2748949.0, style=ProgressStyle(descript…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "8f1077550e0448fda8444c572cef3fcf",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=14.0, style=ProgressStyle(description_w…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "a3b392af274a443aac1490b6d279d4f4",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=104.0, style=ProgressStyle(description_…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "5cf2c4e6005b46589210042a50cf543c",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=728.0, style=ProgressStyle(description_…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "0635cc54c5bc45ffa664f68a2f321d04",
+              "version_minor": 0,
+              "version_major": 2
+            },
+            "text/plain": [
+              "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=485044198.0, style=ProgressStyle(descri…"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -68,17 +2341,17 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 49
+          "height": 47
         },
         "id": "rdIZuoQdt_q9",
-        "outputId": "7ffa707c-f2ca-4751-8748-f504a4254ccc"
+        "outputId": "d290b04d-1df9-4fc1-a898-308e10ab0461"
       },
       "source": [
         "# Generate one token to fill in the blank\n",
         "\n",
         "output_0 = lm.generate(\"۱, ۲, ۳,\", generate=1, do_sample=False)"
       ],
-      "execution_count": 30,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "display_data",
@@ -173,9 +2446,9 @@
               "\n",
               "\n",
               "         requirejs( ['basic', 'ecco'], function(basic, ecco){\n",
-              "            basic.init('viz_979508')\n",
+              "            basic.init('viz_581748')\n",
               "\n",
-              "            window.ecco['viz_979508'] = ecco.renderOutputSequence('viz_979508', {'tokens': [{'token': '۱', 'position': 0, 'token_id': 1168, 'type': 'input'}, {'token': ',', 'position': 1, 'token_id': 22, 'type': 'input'}, {'token': ' ۲', 'position': 2, 'token_id': 469, 'type': 'input'}, {'token': ',', 'position': 3, 'token_id': 22, 'type': 'input'}, {'token': ' ۳', 'position': 4, 'token_id': 1031, 'type': 'input'}, {'token': ',', 'position': 5, 'token_id': 22, 'type': 'input'}]})\n",
+              "            window.ecco['viz_581748'] = ecco.renderOutputSequence('viz_581748', {'tokens': [{'token': '۱', 'position': 0, 'token_id': 1168, 'type': 'input'}, {'token': ',', 'position': 1, 'token_id': 22, 'type': 'input'}, {'token': ' ۲', 'position': 2, 'token_id': 469, 'type': 'input'}, {'token': ',', 'position': 3, 'token_id': 22, 'type': 'input'}, {'token': ' ۳', 'position': 4, 'token_id': 1031, 'type': 'input'}, {'token': ',', 'position': 5, 'token_id': 22, 'type': 'input'}]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })\n"
@@ -196,9 +2469,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_979508');\n",
-              "                window.ecco['viz_979508'].addToken({\"token\": \" \\u06f4\", \"token_id\": 856, \"position\": 6, \"type\": \"output\"})\n",
-              "                window.ecco['viz_979508'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_581748');\n",
+              "                window.ecco['viz_581748'].addToken({\"token\": \" \\u06f4\", \"token_id\": 856, \"position\": 6, \"type\": \"output\"})\n",
+              "                window.ecco['viz_581748'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -217,16 +2490,16 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 138
+          "height": 110
         },
         "id": "2A4PXAo1t9HY",
-        "outputId": "70f0a519-6bf0-433b-9625-be6440646ad9"
+        "outputId": "20563b6d-73c6-43c6-8fd6-b9638a69d5e2"
       },
       "source": [
         "# Visualize\n",
         "output_0.layer_predictions(position=6, layer=8)"
       ],
-      "execution_count": 34,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "display_data",
@@ -325,7 +2598,7 @@
               "\n",
               "            let pred = new ecco.LayerPredictions({\n",
               "                parentDiv: viz_id,\n",
-              "                data:[[{\"token\": \" \\u06f4\", \"prob\": \"0.70661134\", \"ranking\": 1, \"layer\": 8}, {\"token\": \" \\u06f7\", \"prob\": \"0.19815998\", \"ranking\": 2, \"layer\": 8}, {\"token\": \" \\u06f8\", \"prob\": \"0.025307547\", \"ranking\": 3, \"layer\": 8}, {\"token\": \" \\u06f6\", \"prob\": \"0.020839112\", \"ranking\": 4, \"layer\": 8}, {\"token\": \" \\u06f5\", \"prob\": \"0.015064975\", \"ranking\": 5, \"layer\": 8}, {\"token\": \"\\u06f5\", \"prob\": \"0.010315813\", \"ranking\": 6, \"layer\": 8}, {\"token\": \" \\u06f3\", \"prob\": \"0.006504253\", \"ranking\": 7, \"layer\": 8}, {\"token\": \" \\u06f2\", \"prob\": \"0.005209524\", \"ranking\": 8, \"layer\": 8}, {\"token\": \"\\u06f6\", \"prob\": \"0.00430959\", \"ranking\": 9, \"layer\": 8}, {\"token\": \"\\u06f4\", \"prob\": \"0.0039546946\", \"ranking\": 10, \"layer\": 8}]]\n",
+              "                data:[[{\"token\": \" \\u06f4\", \"prob\": \"0.7066119\", \"ranking\": 1, \"layer\": 8}, {\"token\": \" \\u06f7\", \"prob\": \"0.19815935\", \"ranking\": 2, \"layer\": 8}, {\"token\": \" \\u06f8\", \"prob\": \"0.025307566\", \"ranking\": 3, \"layer\": 8}, {\"token\": \" \\u06f6\", \"prob\": \"0.020839129\", \"ranking\": 4, \"layer\": 8}, {\"token\": \" \\u06f5\", \"prob\": \"0.015064958\", \"ranking\": 5, \"layer\": 8}, {\"token\": \"\\u06f5\", \"prob\": \"0.010315781\", \"ranking\": 6, \"layer\": 8}, {\"token\": \" \\u06f3\", \"prob\": \"0.00650427\", \"ranking\": 7, \"layer\": 8}, {\"token\": \" \\u06f2\", \"prob\": \"0.0052095577\", \"ranking\": 8, \"layer\": 8}, {\"token\": \"\\u06f6\", \"prob\": \"0.0043095932\", \"ranking\": 9, \"layer\": 8}, {\"token\": \"\\u06f4\", \"prob\": \"0.0039546974\", \"ranking\": 10, \"layer\": 8}]]\n",
               "            })\n",
               "            pred.init()\n",
               "         }, function (err) {\n",
@@ -347,17 +2620,17 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 49
+          "height": 47
         },
         "id": "VxYu6RYwuLuV",
-        "outputId": "e95a258d-b8c2-4897-a884-b6c00d3c5da4"
+        "outputId": "a61de4d8-f8fc-422b-8cd1-1e7cf576a093"
       },
       "source": [
         "text = \" فرودگاه هیترو در شهر\"\n",
         "\n",
         "output = lm.generate(text, generate=1, do_sample=False)"
       ],
-      "execution_count": 35,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "display_data",
@@ -452,9 +2725,9 @@
               "\n",
               "\n",
               "         requirejs( ['basic', 'ecco'], function(basic, ecco){\n",
-              "            basic.init('viz_816899')\n",
+              "            basic.init('viz_892056')\n",
               "\n",
-              "            window.ecco['viz_816899'] = ecco.renderOutputSequence('viz_816899', {'tokens': [{'token': ' فرودگاه', 'position': 0, 'token_id': 3514, 'type': 'input'}, {'token': ' هی', 'position': 1, 'token_id': 691, 'type': 'input'}, {'token': 'ترو', 'position': 2, 'token_id': 7200, 'type': 'input'}, {'token': ' در', 'position': 3, 'token_id': 298, 'type': 'input'}, {'token': ' شهر', 'position': 4, 'token_id': 622, 'type': 'input'}]})\n",
+              "            window.ecco['viz_892056'] = ecco.renderOutputSequence('viz_892056', {'tokens': [{'token': ' فرودگاه', 'position': 0, 'token_id': 3514, 'type': 'input'}, {'token': ' هی', 'position': 1, 'token_id': 691, 'type': 'input'}, {'token': 'ترو', 'position': 2, 'token_id': 7200, 'type': 'input'}, {'token': ' در', 'position': 3, 'token_id': 298, 'type': 'input'}, {'token': ' شهر', 'position': 4, 'token_id': 622, 'type': 'input'}]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })\n"
@@ -475,9 +2748,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_816899');\n",
-              "                window.ecco['viz_816899'].addToken({\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"token_id\": 4290, \"position\": 5, \"type\": \"output\"})\n",
-              "                window.ecco['viz_816899'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_892056');\n",
+              "                window.ecco['viz_892056'].addToken({\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"token_id\": 4290, \"position\": 5, \"type\": \"output\"})\n",
+              "                window.ecco['viz_892056'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -496,15 +2769,15 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 138
+          "height": 110
         },
         "id": "N2mySmSmt9xW",
-        "outputId": "0932cd7c-e36b-4d8d-e64a-c6d3878cdeba"
+        "outputId": "93257d5d-e7b2-4059-81a4-e321757d5020"
       },
       "source": [
         "output.layer_predictions(position=5, layer=11)"
       ],
-      "execution_count": 47,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "display_data",
@@ -603,7 +2876,7 @@
               "\n",
               "            let pred = new ecco.LayerPredictions({\n",
               "                parentDiv: viz_id,\n",
-              "                data:[[{\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"prob\": \"0.043066192\", \"ranking\": 1, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\", \"prob\": \"0.04225509\", \"ranking\": 2, \"layer\": 11}, {\"token\": \" \\u062a\\u0648\\u06a9\\u06cc\\u0648\", \"prob\": \"0.036114853\", \"ranking\": 3, \"layer\": 11}, {\"token\": \" \\u0646\\u06cc\\u0648\\u06cc\\u0648\\u0631\\u06a9\", \"prob\": \"0.028784556\", \"ranking\": 4, \"layer\": 11}, {\"token\": \" \\u00ab\", \"prob\": \"0.016635172\", \"ranking\": 5, \"layer\": 11}, {\"token\": \" \\u0633\\u06cc\\u062f\\u0646\\u06cc\", \"prob\": \"0.013160528\", \"ranking\": 6, \"layer\": 11}, {\"token\": \" \\u0633\\u0627\\u0646\", \"prob\": \"0.0115857255\", \"ranking\": 7, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0646\", \"prob\": \"0.010992901\", \"ranking\": 8, \"layer\": 11}, {\"token\": \" \\u0631\\u0645\", \"prob\": \"0.009205955\", \"ranking\": 9, \"layer\": 11}, {\"token\": \" \\u0645\\u0644\\u0628\\u0648\\u0631\\u0646\", \"prob\": \"0.008472128\", \"ranking\": 10, \"layer\": 11}]]\n",
+              "                data:[[{\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"prob\": \"0.04306621\", \"ranking\": 1, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\", \"prob\": \"0.04225519\", \"ranking\": 2, \"layer\": 11}, {\"token\": \" \\u062a\\u0648\\u06a9\\u06cc\\u0648\", \"prob\": \"0.036114905\", \"ranking\": 3, \"layer\": 11}, {\"token\": \" \\u0646\\u06cc\\u0648\\u06cc\\u0648\\u0631\\u06a9\", \"prob\": \"0.028784541\", \"ranking\": 4, \"layer\": 11}, {\"token\": \" \\u00ab\", \"prob\": \"0.016635139\", \"ranking\": 5, \"layer\": 11}, {\"token\": \" \\u0633\\u06cc\\u062f\\u0646\\u06cc\", \"prob\": \"0.013160532\", \"ranking\": 6, \"layer\": 11}, {\"token\": \" \\u0633\\u0627\\u0646\", \"prob\": \"0.0115857255\", \"ranking\": 7, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0646\", \"prob\": \"0.01099289\", \"ranking\": 8, \"layer\": 11}, {\"token\": \" \\u0631\\u0645\", \"prob\": \"0.009205946\", \"ranking\": 9, \"layer\": 11}, {\"token\": \" \\u0645\\u0644\\u0628\\u0648\\u0631\\u0646\", \"prob\": \"0.00847214\", \"ranking\": 10, \"layer\": 11}]]\n",
               "            })\n",
               "            pred.init()\n",
               "         }, function (err) {\n",
@@ -625,15 +2898,15 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 208
+          "height": 164
         },
         "id": "jMORLJytt90U",
-        "outputId": "0ead5a60-8474-429c-c74a-918ce731888a"
+        "outputId": "bb9b4e9c-8e7b-46fc-fcb3-f647beedc486"
       },
       "source": [
         "output.layer_predictions(position=5, layer=11, topk=20)"
       ],
-      "execution_count": 55,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "display_data",
@@ -732,7 +3005,7 @@
               "\n",
               "            let pred = new ecco.LayerPredictions({\n",
               "                parentDiv: viz_id,\n",
-              "                data:[[{\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"prob\": \"0.043066192\", \"ranking\": 1, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\", \"prob\": \"0.04225509\", \"ranking\": 2, \"layer\": 11}, {\"token\": \" \\u062a\\u0648\\u06a9\\u06cc\\u0648\", \"prob\": \"0.036114853\", \"ranking\": 3, \"layer\": 11}, {\"token\": \" \\u0646\\u06cc\\u0648\\u06cc\\u0648\\u0631\\u06a9\", \"prob\": \"0.028784556\", \"ranking\": 4, \"layer\": 11}, {\"token\": \" \\u00ab\", \"prob\": \"0.016635172\", \"ranking\": 5, \"layer\": 11}, {\"token\": \" \\u0633\\u06cc\\u062f\\u0646\\u06cc\", \"prob\": \"0.013160528\", \"ranking\": 6, \"layer\": 11}, {\"token\": \" \\u0633\\u0627\\u0646\", \"prob\": \"0.0115857255\", \"ranking\": 7, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0646\", \"prob\": \"0.010992901\", \"ranking\": 8, \"layer\": 11}, {\"token\": \" \\u0631\\u0645\", \"prob\": \"0.009205955\", \"ranking\": 9, \"layer\": 11}, {\"token\": \" \\u0645\\u0644\\u0628\\u0648\\u0631\\u0646\", \"prob\": \"0.008472128\", \"ranking\": 10, \"layer\": 11}, {\"token\": \" \\u067e\\u06a9\\u0646\", \"prob\": \"0.008434038\", \"ranking\": 11, \"layer\": 11}, {\"token\": \" \\u0633\\u0646\", \"prob\": \"0.008193497\", \"ranking\": 12, \"layer\": 11}, {\"token\": \" \\u0645\\u06cc\\u0644\\u0627\\u0646\", \"prob\": \"0.007902964\", \"ranking\": 13, \"layer\": 11}, {\"token\": \" \\u0634\\u06cc\\u06a9\\u0627\\u06af\\u0648\", \"prob\": \"0.007412722\", \"ranking\": 14, \"layer\": 11}, {\"token\": \" \\u067e\\u0627\\u0631\\u06cc\\u0633\", \"prob\": \"0.0071446067\", \"ranking\": 15, \"layer\": 11}, {\"token\": \" \\u0645\\u0633\\u06a9\\u0648\", \"prob\": \"0.0069562704\", \"ranking\": 16, \"layer\": 11}, {\"token\": \" \\u0631\\u06cc\", \"prob\": \"0.0061183395\", \"ranking\": 17, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\\u0648\\u0633\\u062a\\u0648\\u0646\", \"prob\": \"0.005611121\", \"ranking\": 18, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0644\\u0627\\u0646\\u062a\\u0627\", \"prob\": \"0.0055231387\", \"ranking\": 19, \"layer\": 11}, {\"token\": \" \\u0644\\u06cc\\u0633\\u0628\\u0648\\u0646\", \"prob\": \"0.005501016\", \"ranking\": 20, \"layer\": 11}]]\n",
+              "                data:[[{\"token\": \" \\u0644\\u0646\\u062f\\u0646\", \"prob\": \"0.04306621\", \"ranking\": 1, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\", \"prob\": \"0.04225519\", \"ranking\": 2, \"layer\": 11}, {\"token\": \" \\u062a\\u0648\\u06a9\\u06cc\\u0648\", \"prob\": \"0.036114905\", \"ranking\": 3, \"layer\": 11}, {\"token\": \" \\u0646\\u06cc\\u0648\\u06cc\\u0648\\u0631\\u06a9\", \"prob\": \"0.028784541\", \"ranking\": 4, \"layer\": 11}, {\"token\": \" \\u00ab\", \"prob\": \"0.016635139\", \"ranking\": 5, \"layer\": 11}, {\"token\": \" \\u0633\\u06cc\\u062f\\u0646\\u06cc\", \"prob\": \"0.013160532\", \"ranking\": 6, \"layer\": 11}, {\"token\": \" \\u0633\\u0627\\u0646\", \"prob\": \"0.0115857255\", \"ranking\": 7, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0646\", \"prob\": \"0.01099289\", \"ranking\": 8, \"layer\": 11}, {\"token\": \" \\u0631\\u0645\", \"prob\": \"0.009205946\", \"ranking\": 9, \"layer\": 11}, {\"token\": \" \\u0645\\u0644\\u0628\\u0648\\u0631\\u0646\", \"prob\": \"0.00847214\", \"ranking\": 10, \"layer\": 11}, {\"token\": \" \\u067e\\u06a9\\u0646\", \"prob\": \"0.008434029\", \"ranking\": 11, \"layer\": 11}, {\"token\": \" \\u0633\\u0646\", \"prob\": \"0.008193508\", \"ranking\": 12, \"layer\": 11}, {\"token\": \" \\u0645\\u06cc\\u0644\\u0627\\u0646\", \"prob\": \"0.007902968\", \"ranking\": 13, \"layer\": 11}, {\"token\": \" \\u0634\\u06cc\\u06a9\\u0627\\u06af\\u0648\", \"prob\": \"0.0074127354\", \"ranking\": 14, \"layer\": 11}, {\"token\": \" \\u067e\\u0627\\u0631\\u06cc\\u0633\", \"prob\": \"0.0071446197\", \"ranking\": 15, \"layer\": 11}, {\"token\": \" \\u0645\\u0633\\u06a9\\u0648\", \"prob\": \"0.0069562765\", \"ranking\": 16, \"layer\": 11}, {\"token\": \" \\u0631\\u06cc\", \"prob\": \"0.006118342\", \"ranking\": 17, \"layer\": 11}, {\"token\": \" \\u0647\\u06cc\\u0648\\u0633\\u062a\\u0648\\u0646\", \"prob\": \"0.005611121\", \"ranking\": 18, \"layer\": 11}, {\"token\": \" \\u0622\\u062a\\u0644\\u0627\\u0646\\u062a\\u0627\", \"prob\": \"0.005523133\", \"ranking\": 19, \"layer\": 11}, {\"token\": \" \\u0644\\u06cc\\u0633\\u0628\\u0648\\u0646\", \"prob\": \"0.005501008\", \"ranking\": 20, \"layer\": 11}]]\n",
               "            })\n",
               "            pred.init()\n",
               "         }, function (err) {\n",
@@ -763,17 +3036,17 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 145
+          "height": 142
         },
         "id": "ZrIUHsj9t92c",
-        "outputId": "54b5d7be-050f-46b9-dc77-7266f767c4c9"
+        "outputId": "21020cbd-9cd5-4deb-af06-1d2404abbac2"
       },
       "source": [
         "text = \"در یک اتفاق شگفت انگیز، پژوهشگران\"\n",
         "\n",
         "output = lm.generate(text, generate=64, do_sample=True)"
       ],
-      "execution_count": 140,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "display_data",
@@ -868,9 +3141,9 @@
               "\n",
               "\n",
               "         requirejs( ['basic', 'ecco'], function(basic, ecco){\n",
-              "            basic.init('viz_213011')\n",
+              "            basic.init('viz_714681')\n",
               "\n",
-              "            window.ecco['viz_213011'] = ecco.renderOutputSequence('viz_213011', {'tokens': [{'token': 'در', 'position': 0, 'token_id': 589, 'type': 'input'}, {'token': ' یک', 'position': 1, 'token_id': 367, 'type': 'input'}, {'token': ' اتفاق', 'position': 2, 'token_id': 1599, 'type': 'input'}, {'token': ' شگفت', 'position': 3, 'token_id': 3844, 'type': 'input'}, {'token': ' انگیز', 'position': 4, 'token_id': 5904, 'type': 'input'}, {'token': '،', 'position': 5, 'token_id': 305, 'type': 'input'}, {'token': ' پژوهشگران', 'position': 6, 'token_id': 4579, 'type': 'input'}]})\n",
+              "            window.ecco['viz_714681'] = ecco.renderOutputSequence('viz_714681', {'tokens': [{'token': 'در', 'position': 0, 'token_id': 589, 'type': 'input'}, {'token': ' یک', 'position': 1, 'token_id': 367, 'type': 'input'}, {'token': ' اتفاق', 'position': 2, 'token_id': 1599, 'type': 'input'}, {'token': ' شگفت', 'position': 3, 'token_id': 3844, 'type': 'input'}, {'token': ' انگیز', 'position': 4, 'token_id': 5904, 'type': 'input'}, {'token': '،', 'position': 5, 'token_id': 305, 'type': 'input'}, {'token': ' پژوهشگران', 'position': 6, 'token_id': 4579, 'type': 'input'}]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })\n"
@@ -891,9 +3164,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0631\\u0627\\u06cc\", \"token_id\": 366, \"position\": 7, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062a\\u0648\\u0627\\u0646\\u0633\\u062a\\u0646\\u062f\", \"token_id\": 7183, \"position\": 7, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -913,9 +3186,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0646\\u062e\\u0633\\u062a\\u06cc\\u0646\", \"token_id\": 1817, \"position\": 8, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u06cc\\u06a9\", \"token_id\": 367, \"position\": 8, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -935,9 +3208,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0627\\u0631\", \"token_id\": 761, \"position\": 9, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0645\\u0648\\u0644\\u06a9\\u0648\\u0644\", \"token_id\": 7053, \"position\": 9, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -957,9 +3230,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u062a\\u0648\\u062c\\u0647\", \"token_id\": 2298, \"position\": 10, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" RNA\", \"token_id\": 16789, \"position\": 10, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -979,9 +3252,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0634\\u062f\\u0646\\u062f\", \"token_id\": 1436, \"position\": 11, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 11, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1001,9 +3274,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 12, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0648\\u06cc\\u0631\\u0648\\u0633\", \"token_id\": 1816, \"position\": 12, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1023,9 +3296,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u200c\", \"token_id\": 1570, \"position\": 13, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0632\\u06cc\\u06a9\\u0627\", \"token_id\": 25375, \"position\": 13, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1045,9 +3318,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u067e\\u0631\\u0648\\u062a\\u0626\\u06cc\\u0646\", \"token_id\": 4398, \"position\": 14, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0631\\u0627\", \"token_id\": 330, \"position\": 14, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1067,9 +3340,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u0647\\u0627\\u06cc\", \"token_id\": 325, \"position\": 15, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u0632\", \"token_id\": 312, \"position\": 15, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1089,9 +3362,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u0648\\u062c\\u0648\\u062f\", \"token_id\": 1294, \"position\": 16, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0641\\u0631\\u062f\\u06cc\", \"token_id\": 2730, \"position\": 16, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1111,9 +3384,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062f\\u0631\", \"token_id\": 298, \"position\": 17, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0628\\u0647\", \"token_id\": 303, \"position\": 17, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1133,9 +3406,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0633\\u0644\\u0648\\u0644\", \"token_id\": 2829, \"position\": 18, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0641\\u0631\\u062f\", \"token_id\": 1113, \"position\": 18, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1155,9 +3428,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u200c\", \"token_id\": 285, \"position\": 19, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062f\\u06cc\\u06af\\u0631\\u06cc\", \"token_id\": 1145, \"position\": 19, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1177,9 +3450,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u0647\\u0627\\u06cc\", \"token_id\": 325, \"position\": 20, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0645\\u0646\\u062a\\u0642\\u0644\", \"token_id\": 2923, \"position\": 20, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1199,9 +3472,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u067e\\u0633\\u062a\\u0627\\u0646\\u062f\\u0627\\u0631\\u0627\\u0646\", \"token_id\": 13287, \"position\": 21, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u06a9\\u0646\\u0646\\u062f\", \"token_id\": 689, \"position\": 21, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1221,9 +3494,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 22, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \".\", \"token_id\": 24, \"position\": 22, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1243,9 +3516,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u06a9\\u0647\", \"token_id\": 323, \"position\": 23, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u06cc\\u0646\", \"token_id\": 326, \"position\": 23, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1265,9 +3538,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0648\\u0638\\u06cc\\u0641\\u0647\", \"token_id\": 3188, \"position\": 24, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u062a\\u0641\\u0627\\u0642\", \"token_id\": 1599, \"position\": 24, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1287,9 +3560,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u0648\\u0644\\u06cc\\u062f\\u0645\\u062b\\u0644\", \"token_id\": 29777, \"position\": 25, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0639\\u062c\\u06cc\\u0628\", \"token_id\": 3595, \"position\": 25, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1309,9 +3582,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0631\\u0627\", \"token_id\": 330, \"position\": 26, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u06a9\\u0647\", \"token_id\": 323, \"position\": 26, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1331,9 +3604,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0631\", \"token_id\": 327, \"position\": 27, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062a\\u0642\\u0631\\u06cc\\u0628\\u0627\", \"token_id\": 1985, \"position\": 27, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1353,9 +3626,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0639\\u0647\\u062f\\u0647\", \"token_id\": 2693, \"position\": 28, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062f\\u0631\", \"token_id\": 298, \"position\": 28, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1375,9 +3648,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062f\\u0627\\u0631\\u0646\\u062f\", \"token_id\": 712, \"position\": 29, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0645\\u06cc\\u0627\\u0646\\u0647\", \"token_id\": 4720, \"position\": 29, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1397,9 +3670,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 30, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u200c\", \"token_id\": 285, \"position\": 30, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1419,9 +3692,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u06cc\", \"token_id\": 310, \"position\": 31, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u06cc\", \"token_id\": 269, \"position\": 31, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1441,9 +3714,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u200c\", \"token_id\": 285, \"position\": 32, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0633\\u0627\\u0644\", \"token_id\": 415, \"position\": 32, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1463,9 +3736,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u062a\\u0648\\u0627\\u0646\\u0646\\u062f\", \"token_id\": 1006, \"position\": 33, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" 2015\", \"token_id\": 9109, \"position\": 33, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1485,9 +3758,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0627\", \"token_id\": 314, \"position\": 34, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0631\\u062e\", \"token_id\": 2130, \"position\": 34, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1507,9 +3780,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u063a\\u06cc\\u06cc\\u0631\", \"token_id\": 828, \"position\": 35, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062f\\u0627\\u062f\\u0647\", \"token_id\": 658, \"position\": 35, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1529,9 +3802,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0634\\u0631\\u0627\\u06cc\\u0637\", \"token_id\": 1138, \"position\": 36, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0628\\u0648\\u062f\", \"token_id\": 390, \"position\": 36, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1551,9 +3824,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0647\", \"token_id\": 303, \"position\": 37, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 37, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1573,9 +3846,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062e\\u0635\\u0648\\u0635\", \"token_id\": 1279, \"position\": 38, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0628\\u0633\\u06cc\\u0627\\u0631\", \"token_id\": 674, \"position\": 38, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1595,9 +3868,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062f\\u0631\", \"token_id\": 298, \"position\": 39, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062c\\u0627\\u0644\\u0628\", \"token_id\": 2351, \"position\": 39, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1617,9 +3890,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062d\\u0627\\u0644\\u062a\", \"token_id\": 1471, \"position\": 40, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062a\\u0648\\u062c\\u0647\", \"token_id\": 772, \"position\": 40, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1639,9 +3912,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0627\\u0633\\u062a\\u0631\\u0627\\u062d\\u062a\", \"token_id\": 5045, \"position\": 41, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u0633\\u062a\", \"token_id\": 329, \"position\": 41, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1661,9 +3934,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 42, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u061b\", \"token_id\": 556, \"position\": 42, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1683,9 +3956,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u063a\\u06cc\\u06cc\\u0631\", \"token_id\": 828, \"position\": 43, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0632\\u06cc\\u0631\\u0627\", \"token_id\": 1846, \"position\": 43, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1705,9 +3978,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u0633\\u06cc\\u0631\", \"token_id\": 1418, \"position\": 44, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062a\\u0627\", \"token_id\": 399, \"position\": 44, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1727,9 +4000,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u062f\\u0647\\u0646\\u062f\", \"token_id\": 5332, \"position\": 45, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u067e\\u06cc\\u0634\", \"token_id\": 495, \"position\": 45, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1749,9 +4022,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \".\", \"token_id\": 24, \"position\": 46, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u0632\", \"token_id\": 312, \"position\": 46, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1771,9 +4044,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0647\", \"token_id\": 303, \"position\": 47, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u06cc\\u0646\", \"token_id\": 326, \"position\": 47, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1793,9 +4066,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u06af\\u0641\\u062a\\u0647\", \"token_id\": 1023, \"position\": 48, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062a\\u0635\\u0648\\u0631\", \"token_id\": 2826, \"position\": 48, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1815,9 +4088,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0627\\u06cc\\u0646\", \"token_id\": 326, \"position\": 49, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0645\\u06cc\", \"token_id\": 310, \"position\": 49, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1837,9 +4110,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u06cc\\u0645\", \"token_id\": 935, \"position\": 50, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u200c\", \"token_id\": 285, \"position\": 50, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1859,9 +4132,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u067e\\u0698\\u0648\\u0647\\u0634\\u06cc\", \"token_id\": 5296, \"position\": 51, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u0634\\u062f\", \"token_id\": 424, \"position\": 51, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1881,9 +4154,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 52, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0648\\u06cc\\u0631\\u0648\\u0633\", \"token_id\": 1816, \"position\": 52, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1903,9 +4176,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u200c\", \"token_id\": 1570, \"position\": 53, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0632\\u06cc\\u06a9\\u0627\", \"token_id\": 25375, \"position\": 53, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1925,9 +4198,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u067e\\u0631\\u0648\\u062a\\u0626\\u06cc\\u0646\\u06cc\", \"token_id\": 14062, \"position\": 54, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u0632\", \"token_id\": 312, \"position\": 54, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1947,9 +4220,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u06a9\\u0647\", \"token_id\": 323, \"position\": 55, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u06cc\\u06a9\", \"token_id\": 367, \"position\": 55, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1969,9 +4242,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062f\\u0631\", \"token_id\": 298, \"position\": 56, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u067e\\u0634\\u0647\", \"token_id\": 14891, \"position\": 56, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -1991,9 +4264,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0637\\u0648\\u0644\", \"token_id\": 1033, \"position\": 57, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0646\\u0634\\u0626\\u062a\", \"token_id\": 35308, \"position\": 57, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2013,9 +4286,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0686\\u0631\\u062e\\u0647\", \"token_id\": 5081, \"position\": 58, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u06af\\u0631\\u0641\\u062a\\u0647\", \"token_id\": 792, \"position\": 58, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2035,9 +4308,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062d\\u06cc\\u0627\\u062a\", \"token_id\": 4237, \"position\": 59, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0628\\u0627\\u0634\\u062f\", \"token_id\": 577, \"position\": 59, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2057,9 +4330,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062e\\u0648\\u062f\", \"token_id\": 377, \"position\": 60, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \".\", \"token_id\": 24, \"position\": 60, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2079,9 +4352,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u06cc\", \"token_id\": 310, \"position\": 61, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0627\\u0645\\u0627\", \"token_id\": 492, \"position\": 61, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2101,9 +4374,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u200c\", \"token_id\": 285, \"position\": 62, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062f\\u0631\", \"token_id\": 298, \"position\": 62, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2123,9 +4396,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \"\\u062a\\u0648\\u0627\\u0646\\u062f\", \"token_id\": 663, \"position\": 63, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0635\\u0648\\u0631\\u062a\", \"token_id\": 649, \"position\": 63, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2145,9 +4418,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u0647\", \"token_id\": 303, \"position\": 64, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0635\\u062d\\u062a\", \"token_id\": 6083, \"position\": 64, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2167,9 +4440,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u06cc\\u0632\\u0627\\u0646\", \"token_id\": 1252, \"position\": 65, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0686\\u0646\\u06cc\\u0646\", \"token_id\": 1267, \"position\": 65, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2189,9 +4462,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0642\\u0627\\u0628\\u0644\", \"token_id\": 1045, \"position\": 66, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0686\\u06cc\\u0632\\u06cc\", \"token_id\": 1426, \"position\": 66, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2211,9 +4484,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u0648\\u062c\\u0647\\u06cc\", \"token_id\": 3424, \"position\": 67, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \"\\u060c\", \"token_id\": 305, \"position\": 67, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2233,9 +4506,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u062a\\u063a\\u06cc\\u06cc\\u0631\", \"token_id\": 828, \"position\": 68, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u062f\\u0627\\u0646\\u0634\\u0645\\u0646\\u062f\\u0627\\u0646\", \"token_id\": 3612, \"position\": 68, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2255,9 +4528,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0645\\u0633\\u06cc\\u0631\", \"token_id\": 1418, \"position\": 69, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0642\\u0627\\u062f\\u0631\", \"token_id\": 2306, \"position\": 69, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2277,9 +4550,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_213011');\n",
-              "                window.ecco['viz_213011'].addToken({\"token\": \" \\u0628\\u062f\\u0647\\u062f\", \"token_id\": 3866, \"position\": 70, \"type\": \"output\"})\n",
-              "                window.ecco['viz_213011'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_714681');\n",
+              "                window.ecco['viz_714681'].addToken({\"token\": \" \\u0628\\u0648\\u062f\\u0646\\u062f\", \"token_id\": 1146, \"position\": 70, \"type\": \"output\"})\n",
+              "                window.ecco['viz_714681'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2298,15 +4571,15 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 83
+          "height": 81
         },
         "id": "IHnkaROEvsRn",
-        "outputId": "6da71ba9-8eb9-416c-9bf7-88f20a68d5a8"
+        "outputId": "710656fe-f5ce-418f-c29e-ef3635b4bd10"
       },
       "source": [
         "output.saliency()"
       ],
-      "execution_count": 141,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2404,7 +4677,7 @@
               "                // ecco.interactiveTokens(viz_id, {})\n",
               "                window.ecco[viz_id] = new ecco.MinimalHighlighter({\n",
               "                parentDiv: viz_id,\n",
-              "                data: {'tokens': [{'token': 'در', 'token_id': 589, 'type': 'input', 'value': '0.120529495', 'position': 0}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'value': '0.05264326', 'position': 1}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'input', 'value': '0.11394182', 'position': 2}, {'token': ' شگفت', 'token_id': 3844, 'type': 'input', 'value': '0.16398367', 'position': 3}, {'token': ' انگیز', 'token_id': 5904, 'type': 'input', 'value': '0.14254722', 'position': 4}, {'token': '،', 'token_id': 305, 'type': 'input', 'value': '0.058095437', 'position': 5}, {'token': ' پژوهشگران', 'token_id': 4579, 'type': 'input', 'value': '0.34825912', 'position': 6}, {'token': ' برای', 'token_id': 366, 'type': 'output', 'value': '0', 'position': 7}, {'token': ' نخستین', 'token_id': 1817, 'type': 'output', 'value': '0', 'position': 8}, {'token': ' بار', 'token_id': 761, 'type': 'output', 'value': '0', 'position': 9}, {'token': ' متوجه', 'token_id': 2298, 'type': 'output', 'value': '0', 'position': 10}, {'token': ' شدند', 'token_id': 1436, 'type': 'output', 'value': '0', 'position': 11}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 12}, {'token': ' \\u200c', 'token_id': 1570, 'type': 'output', 'value': '0', 'position': 13}, {'token': ' پروتئین', 'token_id': 4398, 'type': 'output', 'value': '0', 'position': 14}, {'token': 'های', 'token_id': 325, 'type': 'output', 'value': '0', 'position': 15}, {'token': ' موجود', 'token_id': 1294, 'type': 'output', 'value': '0', 'position': 16}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 17}, {'token': ' سلول', 'token_id': 2829, 'type': 'output', 'value': '0', 'position': 18}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 19}, {'token': 'های', 'token_id': 325, 'type': 'output', 'value': '0', 'position': 20}, {'token': ' پستانداران', 'token_id': 13287, 'type': 'output', 'value': '0', 'position': 21}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 22}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 23}, {'token': ' وظیفه', 'token_id': 3188, 'type': 'output', 'value': '0', 'position': 24}, {'token': ' تولیدمثل', 'token_id': 29777, 'type': 'output', 'value': '0', 'position': 25}, {'token': ' را', 'token_id': 330, 'type': 'output', 'value': '0', 'position': 26}, {'token': ' بر', 'token_id': 327, 'type': 'output', 'value': '0', 'position': 27}, {'token': ' عهده', 'token_id': 2693, 'type': 'output', 'value': '0', 'position': 28}, {'token': ' دارند', 'token_id': 712, 'type': 'output', 'value': '0', 'position': 29}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 30}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 31}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 32}, {'token': 'توانند', 'token_id': 1006, 'type': 'output', 'value': '0', 'position': 33}, {'token': ' با', 'token_id': 314, 'type': 'output', 'value': '0', 'position': 34}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 35}, {'token': ' شرایط', 'token_id': 1138, 'type': 'output', 'value': '0', 'position': 36}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 37}, {'token': ' خصوص', 'token_id': 1279, 'type': 'output', 'value': '0', 'position': 38}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 39}, {'token': ' حالت', 'token_id': 1471, 'type': 'output', 'value': '0', 'position': 40}, {'token': ' استراحت', 'token_id': 5045, 'type': 'output', 'value': '0', 'position': 41}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 42}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 43}, {'token': ' مسیر', 'token_id': 1418, 'type': 'output', 'value': '0', 'position': 44}, {'token': ' بدهند', 'token_id': 5332, 'type': 'output', 'value': '0', 'position': 45}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 46}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 47}, {'token': ' گفته', 'token_id': 1023, 'type': 'output', 'value': '0', 'position': 48}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 49}, {'token': ' تیم', 'token_id': 935, 'type': 'output', 'value': '0', 'position': 50}, {'token': ' پژوهشی', 'token_id': 5296, 'type': 'output', 'value': '0', 'position': 51}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 52}, {'token': ' \\u200c', 'token_id': 1570, 'type': 'output', 'value': '0', 'position': 53}, {'token': ' پروتئینی', 'token_id': 14062, 'type': 'output', 'value': '0', 'position': 54}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 55}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 56}, {'token': ' طول', 'token_id': 1033, 'type': 'output', 'value': '0', 'position': 57}, {'token': ' چرخه', 'token_id': 5081, 'type': 'output', 'value': '0', 'position': 58}, {'token': ' حیات', 'token_id': 4237, 'type': 'output', 'value': '0', 'position': 59}, {'token': ' خود', 'token_id': 377, 'type': 'output', 'value': '0', 'position': 60}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 61}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 62}, {'token': 'تواند', 'token_id': 663, 'type': 'output', 'value': '0', 'position': 63}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 64}, {'token': ' میزان', 'token_id': 1252, 'type': 'output', 'value': '0', 'position': 65}, {'token': ' قابل', 'token_id': 1045, 'type': 'output', 'value': '0', 'position': 66}, {'token': ' توجهی', 'token_id': 3424, 'type': 'output', 'value': '0', 'position': 67}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 68}, {'token': ' مسیر', 'token_id': 1418, 'type': 'output', 'value': '0', 'position': 69}, {'token': ' بدهد', 'token_id': 3866, 'type': 'output', 'value': '0', 'position': 70}], 'attributions': [[0.12052949517965317, 0.05264326184988022, 0.11394181847572327, 0.16398367285728455, 0.14254721999168396, 0.05809543654322624, 0.3482591211795807], [0.1781502664089203, 0.06820687651634216, 0.12039405107498169, 0.15711303055286407, 0.16788733005523682, 0.04340321943163872, 0.20059633255004883, 0.06424884498119354], [0.08585289865732193, 0.040032535791397095, 0.07826150953769684, 0.12479200959205627, 0.15820591151714325, 0.03708841651678085, 0.17505423724651337, 0.07700830698013306, 0.22370417416095734], [0.11525771021842957, 0.04457148164510727, 0.09094107896089554, 0.1231161430478096, 0.10062672942876816, 0.0298308115452528, 0.20600777864456177, 0.04154171049594879, 0.1282319277524948, 0.11987464874982834], [0.08803491294384003, 0.03329388424754143, 0.07146862149238586, 0.09924773871898651, 0.08452096581459045, 0.026380598545074463, 0.16145983338356018, 0.028535939753055573, 0.0587216354906559, 0.056490447372198105, 0.2918453812599182], [0.09408842772245407, 0.031251899898052216, 0.06169586628675461, 0.08931385725736618, 0.08660504966974258, 0.04297078400850296, 0.15246358513832092, 0.024139394983649254, 0.0757228434085846, 0.03318798914551735, 0.15693354606628418, 0.15162670612335205], [0.11074426770210266, 0.0359828881919384, 0.059685591608285904, 0.09184788912534714, 0.11247868090867996, 0.042484674602746964, 0.14790046215057373, 0.026875022798776627, 0.07459121197462082, 0.03547780588269234, 0.10972238332033157, 0.10522313416004181, 0.046985968947410583], [0.10008340328931808, 0.025656452402472496, 0.04576603323221207, 0.06769827008247375, 0.08492779731750488, 0.028991401195526123, 0.142159104347229, 0.018878484144806862, 0.049313466995954514, 0.027413062751293182, 0.11616713553667068, 0.08785500377416611, 0.04787037894129753, 0.1572200208902359], [0.06682416796684265, 0.02473749779164791, 0.043947797268629074, 0.09157176315784454, 0.11014430969953537, 0.020965108647942543, 0.07059634476900101, 0.012052700854837894, 0.030799003317952156, 0.018830234184861183, 0.04963789880275726, 0.04896589741110802, 0.02399306371808052, 0.036727096885442734, 0.3502071797847748], [0.0683305412530899, 0.017187124118208885, 0.03306121379137039, 0.05194312334060669, 0.06057991087436676, 0.020688673481345177, 0.09220581501722336, 0.015998588874936104, 0.03643724322319031, 0.02707723341882229, 0.051272109150886536, 0.05546336993575096, 0.020004864782094955, 0.03433840721845627, 0.30479511618614197, 0.11061664670705795], [0.061967913061380386, 0.018488025292754173, 0.03545275703072548, 0.05181359127163887, 0.052410148084163666, 0.017373457551002502, 0.08617506176233292, 0.01590169407427311, 0.04398893937468529, 0.02074064500629902, 0.06341993808746338, 0.055386681109666824, 0.015995897352695465, 0.032249629497528076, 0.2015593945980072, 0.05463571846485138, 0.17244043946266174], [0.10801324993371964, 0.01787499710917473, 0.031199021264910698, 0.04383867233991623, 0.04472817853093147, 0.016828149557113647, 0.08445969223976135, 0.012985942885279655, 0.03808780014514923, 0.0188908651471138, 0.05729240924119949, 0.04407313093543053, 0.016005342826247215, 0.033385567367076874, 0.2115548700094223, 0.04349305480718613, 0.1288757026195526, 0.048413392156362534], [0.05091400817036629, 0.01616712659597397, 0.03452746570110321, 0.05129971355199814, 0.05098560452461243, 0.015248192474246025, 0.08821036666631699, 0.014368843287229538, 0.038764189928770065, 0.01923242211341858, 0.056495919823646545, 0.04840634763240814, 0.012078269384801388, 0.025353820994496346, 0.16269926726818085, 0.031153390184044838, 0.03889095410704613, 0.01758343167603016, 0.22762072086334229], [0.05794253200292587, 0.01628996804356575, 0.030956001952290535, 0.048469219356775284, 0.07193323224782944, 0.015065977349877357, 0.08058343827724457, 0.012861005030572414, 0.04086778312921524, 0.019433220848441124, 0.052695419639348984, 0.04321274906396866, 0.02103840932250023, 0.06902316212654114, 0.10923442244529724, 0.03399530053138733, 0.03870614618062973, 0.019765682518482208, 0.17655426263809204, 0.04137201979756355], [0.059533897787332535, 0.013473530299961567, 0.023743199184536934, 0.037638530135154724, 0.03918318822979927, 0.014258407056331635, 0.06322062760591507, 0.011859474703669548, 0.033062104135751724, 0.019262412562966347, 0.03792892023921013, 0.04081698879599571, 0.013224292546510696, 0.022846901789307594, 0.12221086025238037, 0.05412381887435913, 0.04564881697297096, 0.018574092537164688, 0.2247500717639923, 0.047885097563266754, 0.0567547045648098], [0.06679655611515045, 0.017190519720315933, 0.03108084946870804, 0.038217395544052124, 0.0470476932823658, 0.021205104887485504, 0.06444563716650009, 0.014056903310120106, 0.042796023190021515, 0.019443659111857414, 0.05829240754246712, 0.049793828278779984, 0.018263621255755424, 0.022073743864893913, 0.09156564623117447, 0.03186255320906639, 0.04384220018982887, 0.014916411601006985, 0.048949480056762695, 0.008266408927738667, 0.016767537221312523, 0.23312582075595856], [0.05355146899819374, 0.017224840819835663, 0.029187941923737526, 0.0426604263484478, 0.06504445523023605, 0.022366279736161232, 0.06805460900068283, 0.01308570895344019, 0.040810033679008484, 0.019774237647652626, 0.06783484667539597, 0.05948541313409805, 0.022732889279723167, 0.05196090415120125, 0.0975290983915329, 0.026779964566230774, 0.03947295621037483, 0.014418243430554867, 0.037933360785245895, 0.010504367761313915, 0.015254414640367031, 0.15130159258842468, 0.033031951636075974], [0.044610727578401566, 0.013888600282371044, 0.025301320478320122, 0.03200257942080498, 0.037291619926691055, 0.01604093238711357, 0.0637740045785904, 0.014160341583192348, 0.029468804597854614, 0.015509107150137424, 0.04298367351293564, 0.0451163649559021, 0.01663612760603428, 0.0275103896856308, 0.16187900304794312, 0.05149355158209801, 0.03175656124949455, 0.01569346711039543, 0.061871156096458435, 0.009652108885347843, 0.016290457919239998, 0.10452806949615479, 0.048391811549663544, 0.0741492211818695], [0.046329934149980545, 0.017003199085593224, 0.03769191727042198, 0.05262945964932442, 0.07012979686260223, 0.016141319647431374, 0.057715389877557755, 0.009191513061523438, 0.027432991191744804, 0.0148128317669034, 0.036791469901800156, 0.03133179619908333, 0.016394516453146935, 0.030294254422187805, 0.11061524599790573, 0.02585873380303383, 0.0196284931153059, 0.012044275179505348, 0.06659706681966782, 0.011490987613797188, 0.010524553246796131, 0.10530177503824234, 0.01715066470205784, 0.025770606473088264, 0.1311272382736206], [0.022170666605234146, 0.007515456527471542, 0.01275520771741867, 0.01685541681945324, 0.019768359139561653, 0.008365833200514317, 0.03009558841586113, 0.008181165903806686, 0.018263520672917366, 0.007912171073257923, 0.022027689963579178, 0.01678585074841976, 0.00669445563107729, 0.011880561709403992, 0.04938065633177757, 0.013058812357485294, 0.014088821597397327, 0.007192803546786308, 0.04481947422027588, 0.006382938474416733, 0.008895665407180786, 0.07350654155015945, 0.015245949849486351, 0.02427440881729126, 0.0821949690580368, 0.4516870081424713], [0.0316193513572216, 0.01664142496883869, 0.028066735714673996, 0.03340279310941696, 0.06253629922866821, 0.014956277795135975, 0.06107702478766441, 0.012527846731245518, 0.04718412086367607, 0.019503114745020866, 0.045003436505794525, 0.035772960633039474, 0.015543406829237938, 0.03352576494216919, 0.04764629155397415, 0.015532576479017735, 0.019454972818493843, 0.009663033299148083, 0.029114389792084694, 0.0090880012139678, 0.009287944063544273, 0.06675756722688675, 0.017313070595264435, 0.02498612552881241, 0.10500133037567139, 0.1434587687253952, 0.045335397124290466], [0.040057118982076645, 0.013866810128092766, 0.021658478304743767, 0.028256958350539207, 0.044955022633075714, 0.015425854362547398, 0.04593735188245773, 0.01164078339934349, 0.030622445046901703, 0.01509111374616623, 0.03310069814324379, 0.026648936793208122, 0.015577562153339386, 0.028945397585630417, 0.06087426468729973, 0.018932336941361427, 0.020127715542912483, 0.01554876659065485, 0.03285757079720497, 0.009324670769274235, 0.008118847385048866, 0.06494399160146713, 0.0197165384888649, 0.02130477875471115, 0.08254265785217285, 0.1657130867242813, 0.03759758919477463, 0.07061261683702469], [0.04350912943482399, 0.0117940129712224, 0.017678480595350266, 0.027166398242115974, 0.041386693716049194, 0.01175431627780199, 0.037511520087718964, 0.00933605246245861, 0.02735034190118313, 0.012312370352447033, 0.036652546375989914, 0.0314638614654541, 0.01259779091924429, 0.02912917733192444, 0.05133650824427605, 0.020252300426363945, 0.01707075536251068, 0.009374774061143398, 0.02938845194876194, 0.008849911391735077, 0.009274852462112904, 0.06530443578958511, 0.017726220190525055, 0.024164756760001183, 0.04433634132146835, 0.14272987842559814, 0.024084841832518578, 0.03326699882745743, 0.15319624543190002], [0.047412898391485214, 0.01729159615933895, 0.025585124269127846, 0.03476784750819206, 0.06053222715854645, 0.01685561053454876, 0.06244873255491257, 0.012086973525583744, 0.03956989198923111, 0.018232429400086403, 0.05182943493127823, 0.04090454429388046, 0.015310581773519516, 0.03709840402007103, 0.06720246374607086, 0.020530391484498978, 0.022866057232022285, 0.010241278447210789, 0.02432427741587162, 0.01119182351976633, 0.013898319564759731, 0.09146082401275635, 0.02494671568274498, 0.0307119432836771, 0.019031591713428497, 0.07317810505628586, 0.010543742217123508, 0.01156082097440958, 0.04753671959042549, 0.040848683565855026], [0.06375151872634888, 0.016584990546107292, 0.030575070530176163, 0.03978618234395981, 0.044322576373815536, 0.017769979313015938, 0.07163196802139282, 0.013906409032642841, 0.03576689958572388, 0.01830929145216942, 0.07260537892580032, 0.05580201745033264, 0.01504176203161478, 0.03426540270447731, 0.1139865517616272, 0.026516687124967575, 0.031124768778681755, 0.00707507086917758, 0.026405442506074905, 0.004637671634554863, 0.006909787654876709, 0.054560668766498566, 0.014549619518220425, 0.012206066399812698, 0.014515290036797523, 0.06165507435798645, 0.005324540194123983, 0.005999709479510784, 0.03003387711942196, 0.034408170729875565, 0.01997155323624611], [0.07903499901294708, 0.013610418885946274, 0.023362617939710617, 0.03789230436086655, 0.06319800019264221, 0.016094859689474106, 0.03947232663631439, 0.009349821135401726, 0.025776665657758713, 0.012295935302972794, 0.035385359078645706, 0.03596082702279091, 0.019014408811926842, 0.047334786504507065, 0.045795366168022156, 0.020682288333773613, 0.015671927481889725, 0.008824151009321213, 0.031672172248363495, 0.022250987589359283, 0.011274471879005432, 0.04708494991064072, 0.01935906708240509, 0.02244185097515583, 0.018920253962278366, 0.059457797557115555, 0.009633643552660942, 0.009478135965764523, 0.03261106461286545, 0.02773582562804222, 0.031094806268811226, 0.1082279309630394], [0.04200358688831329, 0.012756566517055035, 0.016206713393330574, 0.02200246788561344, 0.11984725296497345, 0.01084932405501604, 0.049216486513614655, 0.007543214596807957, 0.02825181372463703, 0.013501722365617752, 0.030333049595355988, 0.03457537665963173, 0.026713648810982704, 0.08499016612768173, 0.04379117116332054, 0.02162194810807705, 0.017063863575458527, 0.005317079368978739, 0.020406808704137802, 0.022163117304444313, 0.015634708106517792, 0.04561221972107887, 0.011388295330107212, 0.010500124655663967, 0.012649341486394405, 0.07127831876277924, 0.006798418704420328, 0.009531837888062, 0.03563649579882622, 0.028035156428813934, 0.014360911212861538, 0.04263094812631607, 0.06678789854049683], [0.04613664001226425, 0.00979230459779501, 0.019247552379965782, 0.02679455652832985, 0.03542318940162659, 0.011636771261692047, 0.04279673099517822, 0.00870715081691742, 0.023256609216332436, 0.011634673923254013, 0.03453413397073746, 0.035208698362112045, 0.01416589505970478, 0.029419301077723503, 0.08963396400213242, 0.03087901696562767, 0.01975388266146183, 0.006605716422200203, 0.031261686235666275, 0.006061528343707323, 0.007957120425999165, 0.06695055961608887, 0.013382485136389732, 0.01760844886302948, 0.018155984580516815, 0.15290983021259308, 0.007649615872651339, 0.006884512025862932, 0.03626174479722977, 0.024764683097600937, 0.01264912448823452, 0.01479305699467659, 0.007593050133436918, 0.0794897973537445], [0.03572550788521767, 0.010918752290308475, 0.018542645499110222, 0.028910059481859207, 0.027861973270773888, 0.013123911805450916, 0.045623764395713806, 0.00936872698366642, 0.03535052761435509, 0.014019068330526352, 0.033236064016819, 0.03324681520462036, 0.012048963457345963, 0.025090092793107033, 0.09889810532331467, 0.025393294170498848, 0.021118471398949623, 0.010778326541185379, 0.031588684767484665, 0.009296510368585587, 0.008715585805475712, 0.06658339500427246, 0.012191107496619225, 0.012523077428340912, 0.024097232148051262, 0.11542440205812454, 0.013435933738946915, 0.010620003566145897, 0.030910950154066086, 0.016796022653579712, 0.008246609941124916, 0.013970283791422844, 0.014519227668642998, 0.06942977011203766, 0.04239613562822342], [0.03950045630335808, 0.01249300129711628, 0.024573717266321182, 0.033712878823280334, 0.03609582036733627, 0.012554198503494263, 0.05358656123280525, 0.009359144605696201, 0.028025422245264053, 0.012225611135363579, 0.030501263216137886, 0.025835737586021423, 0.009589488618075848, 0.016483237966895103, 0.084063321352005, 0.01602202281355858, 0.02228144370019436, 0.006250270176678896, 0.0365200936794281, 0.006422883365303278, 0.007844123058021069, 0.055222269147634506, 0.009820870123803616, 0.01126785110682249, 0.021959269419312477, 0.09884859621524811, 0.008259588852524757, 0.006706940475851297, 0.029239283874630928, 0.01633574068546295, 0.006648159585893154, 0.012943587265908718, 0.008725474588572979, 0.047615692019462585, 0.026845676824450493, 0.11562033742666245], [0.02913053333759308, 0.011061088182032108, 0.020909370854496956, 0.02996428683400154, 0.03174471855163574, 0.0106118842959404, 0.0449441559612751, 0.007822834886610508, 0.027769125998020172, 0.01040787622332573, 0.027201887220144272, 0.02116522565484047, 0.007662998046725988, 0.014392880722880363, 0.06132799759507179, 0.013879493810236454, 0.0165262371301651, 0.0064588068053126335, 0.03051074407994747, 0.0066957552917301655, 0.007187802344560623, 0.0673983171582222, 0.009856842458248138, 0.011015476658940315, 0.020905064418911934, 0.1137709766626358, 0.007917395792901516, 0.009595567360520363, 0.02761922776699066, 0.014152511954307556, 0.008398817852139473, 0.012949683703482151, 0.007208541035652161, 0.03069131262600422, 0.01935015618801117, 0.07843130081892014, 0.12336315214633942], [0.02417030744254589, 0.011244373396039009, 0.02159697189927101, 0.03764966502785683, 0.06243760511279106, 0.010983810760080814, 0.04911750182509422, 0.009225746616721153, 0.031010005623102188, 0.014673123136162758, 0.031126592308282852, 0.0256684310734272, 0.011818522587418556, 0.023729009553790092, 0.06950945407152176, 0.017961081117391586, 0.016315996646881104, 0.0076661002822220325, 0.03378613293170929, 0.007426184602081776, 0.00827646255493164, 0.04681456834077835, 0.008516071364283562, 0.009144710376858711, 0.019656600430607796, 0.10120239108800888, 0.0063071963377296925, 0.007802621461451054, 0.026857169345021248, 0.01403789035975933, 0.00822308100759983, 0.008876674808561802, 0.007689802907407284, 0.031773023307323456, 0.01819291152060032, 0.06293255090713501, 0.06542964279651642, 0.03114996664226055], [0.023625299334526062, 0.00976650882512331, 0.013427370227873325, 0.019229711964726448, 0.026712464168667793, 0.008511530235409737, 0.030257347971200943, 0.0062660882249474525, 0.014540385454893112, 0.007623175159096718, 0.016182713210582733, 0.014878308400511742, 0.007319650147110224, 0.01730353944003582, 0.04218931123614311, 0.01150145847350359, 0.012445332482457161, 0.01957714557647705, 0.02173645608127117, 0.007651874329894781, 0.007667179685086012, 0.046776361763477325, 0.008552501909434795, 0.00680130859836936, 0.016628429293632507, 0.07525892555713654, 0.006171958055347204, 0.00672014057636261, 0.02320387400686741, 0.011686854995787144, 0.009131746366620064, 0.011457863263785839, 0.007902318611741066, 0.02709449641406536, 0.014077818021178246, 0.04814121127128601, 0.0823177769780159, 0.07660701870918274, 0.18305648863315582], [0.02983459085226059, 0.00876541156321764, 0.015478495508432388, 0.021141869947314262, 0.028333298861980438, 0.007991625927388668, 0.031873103231191635, 0.006998905912041664, 0.020378554239869118, 0.00827453751116991, 0.01865607500076294, 0.01640573889017105, 0.00671016750857234, 0.018084021285176277, 0.05144047737121582, 0.014447595924139023, 0.014228635467588902, 0.01667947508394718, 0.04345915466547012, 0.008857263252139091, 0.008958968333899975, 0.08512511849403381, 0.007791391108185053, 0.009315677918493748, 0.020554352551698685, 0.11197768896818161, 0.0056582228280603886, 0.006070716306567192, 0.0219848845154047, 0.011733817867934704, 0.005927873309701681, 0.007879055105149746, 0.007551038637757301, 0.023876121267676353, 0.008395369164645672, 0.034817423671483994, 0.052583787590265274, 0.036174070090055466, 0.11520995199680328, 0.030375543981790543], [0.041284237056970596, 0.008781597018241882, 0.014768492430448532, 0.020450100302696228, 0.02318144217133522, 0.00769482646137476, 0.030144942924380302, 0.004638934042304754, 0.015627102926373482, 0.006582286674529314, 0.01929810456931591, 0.01438814215362072, 0.005691582337021828, 0.015776431187987328, 0.049784500151872635, 0.009341450408101082, 0.010958125814795494, 0.007668324280530214, 0.05670952424407005, 0.005881089251488447, 0.006704926490783691, 0.06907273083925247, 0.00560866529121995, 0.006354379002004862, 0.017034566029906273, 0.14992497861385345, 0.003772775176912546, 0.004320124164223671, 0.0164119191467762, 0.009169688448309898, 0.004035527352243662, 0.00875986646860838, 0.004575397819280624, 0.01607222855091095, 0.006890163756906986, 0.029388658702373505, 0.03884439170360565, 0.019305776804685593, 0.05248437449336052, 0.02589373290538788, 0.13672392070293427], [0.025878850370645523, 0.007922647520899773, 0.015164638869464397, 0.020796122029423714, 0.024884240701794624, 0.00924538355320692, 0.03706261143088341, 0.006964599713683128, 0.02181232161819935, 0.00884274858981371, 0.023262126371264458, 0.02033206820487976, 0.008248033933341503, 0.013621088117361069, 0.04034150764346123, 0.010296312160789967, 0.014137230813503265, 0.006526845041662455, 0.026690049096941948, 0.005629427265375853, 0.006105534732341766, 0.05993012338876724, 0.007207442540675402, 0.007751126307994127, 0.023198692128062248, 0.07169150561094284, 0.007104802876710892, 0.005934710614383221, 0.029638366773724556, 0.015337328426539898, 0.00618871720507741, 0.0103116724640131, 0.005945871118456125, 0.03045518696308136, 0.012958085164427757, 0.02874944731593132, 0.02029919996857643, 0.014989282004535198, 0.036869749426841736, 0.010980455204844475, 0.06325145065784454, 0.17744244635105133], [0.021101094782352448, 0.007759347558021545, 0.01571401208639145, 0.023843547329306602, 0.029750237241387367, 0.009337883442640305, 0.041181374341249466, 0.006687036249786615, 0.019088920205831528, 0.008862264454364777, 0.027966823428869247, 0.021983664482831955, 0.008948209695518017, 0.017320076003670692, 0.06725183874368668, 0.013977715745568275, 0.01729924976825714, 0.006360906176269054, 0.02956954576075077, 0.004874304868280888, 0.005248177796602249, 0.04804839566349983, 0.008113812655210495, 0.008160565048456192, 0.01733550801873207, 0.10927131026983261, 0.006925970781594515, 0.006499411538243294, 0.028339333832263947, 0.01963910460472107, 0.008336648344993591, 0.01034428458660841, 0.006927895825356245, 0.04203983023762703, 0.012095862999558449, 0.04858672246336937, 0.02594720385968685, 0.010998333804309368, 0.03179777413606644, 0.005774938967078924, 0.02464810200035572, 0.08873103559017181, 0.027311690151691437], [0.02847410924732685, 0.007838752120733261, 0.014425584115087986, 0.022820819169282913, 0.02101278491318226, 0.008090594783425331, 0.03180402144789696, 0.005720345303416252, 0.016739115118980408, 0.007369778119027615, 0.02170374058187008, 0.018655048683285713, 0.007504118140786886, 0.015125450678169727, 0.06309313327074051, 0.019393743947148323, 0.013765685260295868, 0.0071968091651797295, 0.02503790333867073, 0.004892864730209112, 0.005723229143768549, 0.03992506116628647, 0.009264303371310234, 0.011297371238470078, 0.018967030569911003, 0.07153468579053879, 0.006542201153934002, 0.005590933840721846, 0.02073519304394722, 0.01162080280482769, 0.006080196239054203, 0.010978464968502522, 0.004340358544141054, 0.033759705722332, 0.008494654670357704, 0.06160948798060417, 0.03544219583272934, 0.015256649814546108, 0.04435117170214653, 0.005563290324062109, 0.03210841119289398, 0.07290612161159515, 0.017434684559702873, 0.08980940282344818], [0.023875495418906212, 0.008324280381202698, 0.01676822453737259, 0.02313080243766308, 0.02957409992814064, 0.008928481489419937, 0.034959178417921066, 0.005954867694526911, 0.0186776053160429, 0.008419840596616268, 0.022928692400455475, 0.016898537054657936, 0.007292784750461578, 0.015258022584021091, 0.06257279962301254, 0.014270994812250137, 0.011962885968387127, 0.00649029528722167, 0.026599638164043427, 0.004960846621543169, 0.0047897049225866795, 0.04795345291495323, 0.006782170385122299, 0.006961136125028133, 0.014539480209350586, 0.060424137860536575, 0.007315455004572868, 0.005378605332225561, 0.02008294314146042, 0.010759550146758556, 0.006643347442150116, 0.009995614178478718, 0.005966442637145519, 0.03449074178934097, 0.010989979840815067, 0.03529344126582146, 0.022574344649910927, 0.014440908096730709, 0.043270934373140335, 0.006526229437440634, 0.02094792015850544, 0.05471450090408325, 0.01855285093188286, 0.053106460720300674, 0.10965131223201752], [0.04701139032840729, 0.012011763639748096, 0.02035086788237095, 0.024072719737887383, 0.031011752784252167, 0.011480612680315971, 0.04739242047071457, 0.007057922892272472, 0.023368244990706444, 0.009773638099431992, 0.029572870582342148, 0.024299930781126022, 0.010724709369242191, 0.024332396686077118, 0.0321577712893486, 0.011415640823543072, 0.010434090159833431, 0.007279521785676479, 0.014395542442798615, 0.00485839881002903, 0.005411325953900814, 0.04349474608898163, 0.00744286086410284, 0.008135446347296238, 0.024080228060483932, 0.04545501619577408, 0.006542510818690062, 0.004095656331628561, 0.01987125724554062, 0.015155024826526642, 0.006857193075120449, 0.009403699077665806, 0.00463448092341423, 0.02754308097064495, 0.006367674097418785, 0.018542278558015823, 0.015861432999372482, 0.014159445650875568, 0.0486377514898777, 0.003166421316564083, 0.013803715817630291, 0.02527938410639763, 0.0087586073204875, 0.02846771851181984, 0.05068950727581978, 0.1351412683725357], [0.09975061565637589, 0.014223081059753895, 0.02451861836016178, 0.03264414891600609, 0.04479493200778961, 0.009877345524728298, 0.07547002285718918, 0.00842051301151514, 0.03684719651937485, 0.0171255711466074, 0.04008178412914276, 0.03489142656326294, 0.010658619925379753, 0.03315305709838867, 0.03893883153796196, 0.010742067359387875, 0.011416872031986713, 0.0049164132215082645, 0.01800907775759697, 0.00603839848190546, 0.0062896693125367165, 0.04038793593645096, 0.006729696411639452, 0.009881161153316498, 0.013538113795220852, 0.0506141260266304, 0.004194850567728281, 0.004910266026854515, 0.015419200994074345, 0.014109690673649311, 0.00614056596532464, 0.007117789704352617, 0.005054481327533722, 0.016859859228134155, 0.0038593593053519726, 0.010296246968209743, 0.013760125264525414, 0.005924637895077467, 0.02902049571275711, 0.003285905346274376, 0.011484887450933456, 0.02426757849752903, 0.00569903664290905, 0.010263906791806221, 0.02877836301922798, 0.0369156189262867, 0.042677804827690125], [0.03474356606602669, 0.014470912516117096, 0.025459399446845055, 0.0332535058259964, 0.04835524782538414, 0.009535199031233788, 0.06311067193746567, 0.008417968638241291, 0.037445440888404846, 0.014953781850636005, 0.04639142379164696, 0.04134175181388855, 0.00911659188568592, 0.027415355667471886, 0.031752802431583405, 0.011099805124104023, 0.012004981748759747, 0.006594642531126738, 0.01899026706814766, 0.008391340263187885, 0.007167650852352381, 0.04529048129916191, 0.006170907989144325, 0.010058105923235416, 0.016694776713848114, 0.05261877551674843, 0.00427967868745327, 0.0057023316621780396, 0.020379850640892982, 0.008855138905346394, 0.006354381795972586, 0.00983535498380661, 0.006498711183667183, 0.017023945227265358, 0.0048916758969426155, 0.011492464691400528, 0.016527341678738594, 0.016560455784201622, 0.04378417506814003, 0.004118373151868582, 0.012669778428971767, 0.022966155782341957, 0.006322756875306368, 0.010616025887429714, 0.028024569153785706, 0.04414300620555878, 0.03976358100771904, 0.018344838172197342], [0.047492608428001404, 0.013206868432462215, 0.025284383445978165, 0.03450476750731468, 0.05188160762190819, 0.010967062786221504, 0.08303485810756683, 0.006989249028265476, 0.03632153943181038, 0.013828378170728683, 0.03633755072951317, 0.03556478023529053, 0.009209815412759781, 0.02458053268492222, 0.02982148341834545, 0.00788787193596363, 0.010707463137805462, 0.004611768294125795, 0.021408896893262863, 0.006376729346811771, 0.005909270141273737, 0.0379803441464901, 0.007732429075986147, 0.009182333014905453, 0.015634426847100258, 0.05708139017224312, 0.003659059526398778, 0.004725994076579809, 0.015894349664449692, 0.009621065109968185, 0.004784575663506985, 0.009077279828488827, 0.004865379072725773, 0.014689904637634754, 0.00300556980073452, 0.007443372160196304, 0.010748973116278648, 0.006631850730627775, 0.028270823881030083, 0.00294078653678298, 0.011175001040101051, 0.018270030617713928, 0.004537580534815788, 0.008039090782403946, 0.020315062254667282, 0.031042462214827538, 0.026820408180356026, 0.03318937122821808, 0.07671356201171875], [0.04510235786437988, 0.014638680964708328, 0.025409623980522156, 0.04260822385549545, 0.043994028121232986, 0.012055540457367897, 0.11047309637069702, 0.006942081265151501, 0.024375032633543015, 0.01002446934580803, 0.029565414413809776, 0.023615960031747818, 0.007376356981694698, 0.019330408424139023, 0.029968760907649994, 0.0082174614071846, 0.008926328271627426, 0.004823719151318073, 0.016920579597353935, 0.00533269764855504, 0.005953256506472826, 0.03858102113008499, 0.004264535382390022, 0.006471247877925634, 0.01317687053233385, 0.04582805931568146, 0.003273691050708294, 0.00379620841704309, 0.01540686096996069, 0.007669519167393446, 0.004940904676914215, 0.011843213811516762, 0.011790651828050613, 0.014348468743264675, 0.003350412705913186, 0.008949270471930504, 0.011639252305030823, 0.004966771230101585, 0.02015303447842598, 0.003725020680576563, 0.012420179322361946, 0.018669268116354942, 0.00516931526362896, 0.008279695175588131, 0.02409655600786209, 0.025592001155018806, 0.016685616225004196, 0.0245257206261158, 0.08287200331687927, 0.051860518753528595], [0.026955852285027504, 0.009360763244330883, 0.01563074253499508, 0.019674144685268402, 0.030366109684109688, 0.008088156580924988, 0.062187664210796356, 0.005770949646830559, 0.030296247452497482, 0.009378816932439804, 0.023129543289542198, 0.019897889345884323, 0.006030659656971693, 0.01351898442953825, 0.02582797221839428, 0.008646647445857525, 0.008142703212797642, 0.0035906347911804914, 0.02151148021221161, 0.007849235087633133, 0.005583308171480894, 0.08586321026086807, 0.004613630473613739, 0.0043863411992788315, 0.018006540834903717, 0.08122483640909195, 0.002914358163252473, 0.00297124357894063, 0.01909632794559002, 0.00758900074288249, 0.0035439464263617992, 0.005656686145812273, 0.00676919799298048, 0.013069860637187958, 0.002973637543618679, 0.007419851142913103, 0.01110713742673397, 0.006066063418984413, 0.028527621179819107, 0.0025827744975686073, 0.012737681157886982, 0.03192729130387306, 0.003312548855319619, 0.008105194196105003, 0.016652856022119522, 0.024595139548182487, 0.014722543768584728, 0.009602183476090431, 0.03455231338739395, 0.04196911305189133, 0.12600232660770416], [0.03858106955885887, 0.011732667684555054, 0.020348690450191498, 0.02983858808875084, 0.03930381312966347, 0.021778110414743423, 0.04851367324590683, 0.007815578021109104, 0.0230307187885046, 0.011166864074766636, 0.02848093956708908, 0.027432043105363846, 0.013636640273034573, 0.02133893594145775, 0.030853567644953728, 0.008357006125152111, 0.010054351761937141, 0.006336188409477472, 0.018069596961140633, 0.00556298578158021, 0.007082946598529816, 0.04343267157673836, 0.010792032815515995, 0.006058176979422569, 0.01046980544924736, 0.04351440444588661, 0.0033457931131124496, 0.004119297955185175, 0.01286766491830349, 0.009085255675017834, 0.005389842204749584, 0.008344549685716629, 0.005817938130348921, 0.011694595217704773, 0.0031334899831563234, 0.007118099369108677, 0.011041178368031979, 0.010006621479988098, 0.03588394075632095, 0.0028171134181320667, 0.009602272883057594, 0.018141021952033043, 0.005001673940569162, 0.006452590227127075, 0.012736733071506023, 0.02057741768658161, 0.020127831026911736, 0.014730121940374374, 0.04779386520385742, 0.02256048284471035, 0.04396427422761917, 0.10406427830457687], [0.031387459486722946, 0.015259623527526855, 0.01992468349635601, 0.02662709914147854, 0.06872310489416122, 0.013489000499248505, 0.05212916433811188, 0.011493148282170296, 0.033647190779447556, 0.016039537265896797, 0.04692530259490013, 0.04616546630859375, 0.025176746770739555, 0.11961931735277176, 0.03782583028078079, 0.008955612778663635, 0.006058395840227604, 0.003433807985857129, 0.014489298686385155, 0.004708132240921259, 0.0047163874842226505, 0.02828015573322773, 0.005668531637638807, 0.004308914765715599, 0.008131799288094044, 0.03524898737668991, 0.0026006840635091066, 0.002964874729514122, 0.010697757825255394, 0.0065068393014371395, 0.004951030481606722, 0.005276763346046209, 0.003123578615486622, 0.009777619503438473, 0.0026089174207299948, 0.006989248096942902, 0.008900581859052181, 0.0057887183502316475, 0.02182919718325138, 0.0021279065404087305, 0.008258233778178692, 0.01601771079003811, 0.0060609858483076096, 0.005624422803521156, 0.009582565166056156, 0.017538174986839294, 0.014644200913608074, 0.008413945324718952, 0.03123326785862446, 0.01068614237010479, 0.016493843868374825, 0.05100877210497856, 0.0218613650649786], [0.034983642399311066, 0.006946560461074114, 0.015138527378439903, 0.02029646746814251, 0.034087348729372025, 0.007464866619557142, 0.0352475680410862, 0.007043035700917244, 0.019419638440012932, 0.009628538973629475, 0.021814849227666855, 0.023048430681228638, 0.008684083819389343, 0.04771150276064873, 0.14330413937568665, 0.012381203472614288, 0.00853792019188404, 0.0040978542529046535, 0.026233239099383354, 0.004455856513231993, 0.005881000310182571, 0.06067219376564026, 0.005314229987561703, 0.006697984877973795, 0.012392885982990265, 0.03661937639117241, 0.0029452762100845575, 0.0037770697381347418, 0.014735380187630653, 0.007842336781322956, 0.004295347258448601, 0.0055399672128260136, 0.003939120098948479, 0.012772596441209316, 0.0034969972912222147, 0.00989576056599617, 0.012396201491355896, 0.004095722455531359, 0.018978197127580643, 0.003253624541684985, 0.013530529104173183, 0.029902668669819832, 0.004138116259127855, 0.005357612855732441, 0.010548889636993408, 0.019940374419093132, 0.008663247339427471, 0.007123899646103382, 0.019388310611248016, 0.007620113901793957, 0.020902348682284355, 0.03775303438305855, 0.029970532283186913, 0.059093743562698364], [0.02026274986565113, 0.006719354074448347, 0.012157377786934376, 0.01844494603574276, 0.020736169070005417, 0.007120243273675442, 0.03118736669421196, 0.00608812365680933, 0.01716524548828602, 0.007394380401819944, 0.020687896758317947, 0.019250184297561646, 0.006540071684867144, 0.015151453204452991, 0.05928529426455498, 0.02356410212814808, 0.01845904253423214, 0.004131689202040434, 0.017572512850165367, 0.003514608833938837, 0.003153206780552864, 0.036250971257686615, 0.005260361824184656, 0.004982423037290573, 0.009348941966891289, 0.047316133975982666, 0.002850132994353771, 0.003242870094254613, 0.011233553290367126, 0.00602114200592041, 0.004491926170885563, 0.0046926336362957954, 0.0028354257810860872, 0.010025622323155403, 0.002491217805072665, 0.006092552561312914, 0.01000842172652483, 0.0031670446041971445, 0.015021120198071003, 0.002167732687667012, 0.009615489281713963, 0.02744324319064617, 0.005140367895364761, 0.006163475569337606, 0.015138356015086174, 0.019116900861263275, 0.011199211701750755, 0.008188685402274132, 0.02567252889275551, 0.00754750519990921, 0.022478632628917694, 0.047629792243242264, 0.020627589896321297, 0.01122608408331871, 0.236725851893425], [0.017016204074025154, 0.007682042196393013, 0.0130418436601758, 0.02169671654701233, 0.021423814818263054, 0.006701107136905193, 0.03571668267250061, 0.0057726046070456505, 0.01659170538187027, 0.007929446175694466, 0.019258471205830574, 0.01839827001094818, 0.007077256683260202, 0.017802905291318893, 0.05807417631149292, 0.014238283969461918, 0.027539512142539024, 0.011715526692569256, 0.021532533690333366, 0.004473241977393627, 0.004815760999917984, 0.039860110729932785, 0.0059779370203614235, 0.012195160612463951, 0.014054626226425171, 0.04145766422152519, 0.00395161472260952, 0.003314552130177617, 0.011609171517193317, 0.006895784288644791, 0.003883852856233716, 0.0048763444647192955, 0.0032645391765981913, 0.011178969405591488, 0.0031879956368356943, 0.008717580698430538, 0.009504579938948154, 0.004689384717494249, 0.016739824786782265, 0.005323697812855244, 0.011602628976106644, 0.04119078442454338, 0.004174907226115465, 0.007971448823809624, 0.012682770378887653, 0.01982242614030838, 0.011991102248430252, 0.005971377249807119, 0.018315892666578293, 0.009055017493665218, 0.020522011443972588, 0.04629485681653023, 0.010989288799464703, 0.014928234741091728, 0.1711771935224533, 0.024128610268235207], [0.016186900436878204, 0.007116301450878382, 0.011716265231370926, 0.015134993009269238, 0.018847428262233734, 0.006065036170184612, 0.02771717868745327, 0.004735896829515696, 0.020692162215709686, 0.006827071309089661, 0.015945691615343094, 0.013974581845104694, 0.006573436316102743, 0.012768728658556938, 0.049848176538944244, 0.008895553648471832, 0.013013032265007496, 0.007987994700670242, 0.03176150843501091, 0.004407182335853577, 0.004387617111206055, 0.045080769807100296, 0.0043617249466478825, 0.0070111402310431, 0.010683376342058182, 0.042630188167095184, 0.0029567971359938383, 0.0030751987360417843, 0.012152974493801594, 0.005787063855677843, 0.0039656455628573895, 0.00446414016187191, 0.0035535681527107954, 0.01199517585337162, 0.0034596689511090517, 0.010411559604108334, 0.01519244909286499, 0.005960548762232065, 0.018926145508885384, 0.009386952966451645, 0.021240251138806343, 0.09336092323064804, 0.004087864421308041, 0.007223859895020723, 0.015433348715305328, 0.018195156008005142, 0.010188326239585876, 0.005274804309010506, 0.015686847269535065, 0.00737431924790144, 0.01406862773001194, 0.036583926528692245, 0.011527582071721554, 0.011312874965369701, 0.15327265858650208, 0.027055712416768074, 0.022455181926488876], [0.01906944066286087, 0.005958300083875656, 0.015048344619572163, 0.015659328550100327, 0.01647728495299816, 0.0053595807403326035, 0.02566666528582573, 0.0040894765406847, 0.013072122819721699, 0.0049355714581906796, 0.01272435300052166, 0.012867976911365986, 0.004773365333676338, 0.01195637509226799, 0.037355683743953705, 0.007273557595908642, 0.009222464635968208, 0.00464995251968503, 0.027631884440779686, 0.002967691048979759, 0.00403652573004365, 0.046796757727861404, 0.0032680672593414783, 0.004954454954713583, 0.014959060586988926, 0.13058379292488098, 0.0022330351639539003, 0.0023584216833114624, 0.008792759850621223, 0.003914192318916321, 0.0026736794970929623, 0.0030946682672947645, 0.002172990469262004, 0.007452249992638826, 0.0023420758079737425, 0.007828744128346443, 0.011700564064085484, 0.0027588936500251293, 0.011597982607781887, 0.0046014036051929, 0.017544634640216827, 0.09604565799236298, 0.0028475888539105654, 0.0075643910095095634, 0.023921141400933266, 0.014287440106272697, 0.008895568549633026, 0.003581560915336013, 0.011319330893456936, 0.0049357968382537365, 0.012608181685209274, 0.03335021808743477, 0.005554205272346735, 0.007324971258640289, 0.09236738830804825, 0.011453007347881794, 0.03113643452525139, 0.08038276433944702], [0.01868036389350891, 0.005893760826438665, 0.011055871844291687, 0.015526464208960533, 0.01688413694500923, 0.004647297319024801, 0.024357417598366737, 0.0034597287885844707, 0.01192487496882677, 0.005557807628065348, 0.010911667719483376, 0.011468151584267616, 0.004569604992866516, 0.010753754526376724, 0.034852173179388046, 0.006345479749143124, 0.006372409872710705, 0.0033612914849072695, 0.023786477744579315, 0.0035145801957696676, 0.0040234667249023914, 0.05323634296655655, 0.002960375277325511, 0.003612298984080553, 0.01192494761198759, 0.1405707150697708, 0.0021006432361900806, 0.001809683977626264, 0.0074834804981946945, 0.0039956578984856606, 0.0026862300001084805, 0.004038199782371521, 0.002145015634596348, 0.0060294694267213345, 0.0020896224305033684, 0.006023581139743328, 0.007323124911636114, 0.002621613210067153, 0.00993301160633564, 0.0036719960626214743, 0.01421299111098051, 0.07009006291627884, 0.002018087776377797, 0.0040933904238045216, 0.009177428670227528, 0.009096834808588028, 0.007347744889557362, 0.002965311286970973, 0.009866422973573208, 0.0026719991583377123, 0.010379348881542683, 0.024049460887908936, 0.003507304936647415, 0.0044554611667990685, 0.06167106330394745, 0.005577804986387491, 0.012140090577304363, 0.04971478134393692, 0.184761643409729], [0.013795620761811733, 0.005289959721267223, 0.009821146726608276, 0.01509466115385294, 0.015083140693604946, 0.004861706402152777, 0.025720005854964256, 0.003918890375643969, 0.011840242892503738, 0.005926691461354494, 0.011694981716573238, 0.010385639034211636, 0.004873496945947409, 0.009692125953733921, 0.03834424912929535, 0.008640014566481113, 0.010411690920591354, 0.004310098011046648, 0.01679810881614685, 0.002971350448206067, 0.003951499704271555, 0.05201496183872223, 0.0035901411902159452, 0.004545451141893864, 0.007893710397183895, 0.04715670645236969, 0.0023750290274620056, 0.0025264224968850613, 0.00834295991808176, 0.0051609729416668415, 0.002310603391379118, 0.0029871307779103518, 0.0018240530043840408, 0.006458372808992863, 0.001879517687484622, 0.005101773887872696, 0.0076604881323874, 0.0028317514806985855, 0.010143144987523556, 0.003233034862205386, 0.008069473318755627, 0.01936633139848709, 0.0024721226654946804, 0.004905671812593937, 0.010908917523920536, 0.014189758338034153, 0.0068022324703633785, 0.0027398860547691584, 0.010730692185461521, 0.004664687439799309, 0.01490574050694704, 0.03253621980547905, 0.007022569887340069, 0.007433340419083834, 0.1585296392440796, 0.008221416734158993, 0.010880746878683567, 0.029625099152326584, 0.0936238020658493, 0.14091002941131592], [0.014235883951187134, 0.004462751559913158, 0.008681200444698334, 0.01245089154690504, 0.017602745443582535, 0.005430880002677441, 0.02022460661828518, 0.00371229974552989, 0.010391799733042717, 0.005097521003335714, 0.013031406328082085, 0.010898481123149395, 0.006727591156959534, 0.015609593130648136, 0.05445641279220581, 0.00988355278968811, 0.00764257600530982, 0.004736746195703745, 0.012486021965742111, 0.0046709137968719006, 0.0050564901903271675, 0.02824106067419052, 0.004235223401337862, 0.008790422230958939, 0.011968865990638733, 0.046743955463171005, 0.003476000390946865, 0.0032184431329369545, 0.01104876957833767, 0.008372812531888485, 0.004792925901710987, 0.007688031531870365, 0.010154235176742077, 0.011269194073975086, 0.0028434887062758207, 0.009207707829773426, 0.009079101495444775, 0.004088073968887329, 0.01173497922718525, 0.004832425620406866, 0.009043565019965172, 0.0247088260948658, 0.004106500651687384, 0.006266070529818535, 0.012485084123909473, 0.016152217984199524, 0.00908750668168068, 0.0047342730686068535, 0.012542346492409706, 0.005622680764645338, 0.015377964824438095, 0.029243487864732742, 0.007337846793234348, 0.011033289134502411, 0.12032708525657654, 0.017659073695540428, 0.010072248056530952, 0.027450259774923325, 0.0645587369799614, 0.08756352961063385, 0.055351290851831436], [0.042479272931814194, 0.009792530909180641, 0.015763290226459503, 0.02543635107576847, 0.06340646743774414, 0.008628697134554386, 0.029885463416576385, 0.005189557559788227, 0.01530161127448082, 0.008036785759031773, 0.019651902839541435, 0.02114548720419407, 0.011491261422634125, 0.03576933965086937, 0.0282755047082901, 0.014454652555286884, 0.00920793879777193, 0.004833196755498648, 0.018987521529197693, 0.01139175333082676, 0.007333083543926477, 0.035215262323617935, 0.007181371096521616, 0.009862360544502735, 0.01273399405181408, 0.05341300368309021, 0.004173822235316038, 0.004939673468470573, 0.01770150475203991, 0.011972825974225998, 0.005857931450009346, 0.031771961599588394, 0.016095953062176704, 0.009331637993454933, 0.002701089484617114, 0.006288544274866581, 0.006481064949184656, 0.006441305857151747, 0.024189045652747154, 0.0027514358516782522, 0.005705890245735645, 0.012613127008080482, 0.0048003732226789, 0.004610207863152027, 0.009186595678329468, 0.013888268731534481, 0.011252198368310928, 0.0051452466286718845, 0.010540791787207127, 0.005376498214900494, 0.006785002537071705, 0.01991979032754898, 0.007249991409480572, 0.013099725358188152, 0.02780456468462944, 0.009363955818116665, 0.005889526102691889, 0.009766075760126114, 0.021785227581858635, 0.035979315638542175, 0.025767652317881584, 0.05790446698665619], [0.015893522650003433, 0.006482863333076239, 0.007577146869152784, 0.010003923438489437, 0.0542493499815464, 0.0048537529073655605, 0.024803215637803078, 0.0034585040993988514, 0.017756519839167595, 0.005838362965732813, 0.011530723422765732, 0.013091999106109142, 0.006953160744160414, 0.029174184426665306, 0.01992865465581417, 0.010671917349100113, 0.005587555002421141, 0.003458029590547085, 0.00965601671487093, 0.013238208368420601, 0.010410466231405735, 0.02389187179505825, 0.004087781999260187, 0.005904681049287319, 0.00788397528231144, 0.044371604919433594, 0.002633066149428487, 0.003908402752131224, 0.011105610057711601, 0.007509544957429171, 0.004240956157445908, 0.007454190403223038, 0.010055727325379848, 0.019724499434232712, 0.002284300746396184, 0.004260256886482239, 0.005944586358964443, 0.003130843862891197, 0.01651698164641857, 0.0035552778281271458, 0.005802726838737726, 0.014277641661465168, 0.004541066009551287, 0.00434194877743721, 0.009649463929235935, 0.017003899440169334, 0.008115561679005623, 0.006037600804120302, 0.01338995061814785, 0.006533125415444374, 0.010502682067453861, 0.026347815990447998, 0.013667085207998753, 0.03287992253899574, 0.06599364429712296, 0.0161002054810524, 0.00887269340455532, 0.023309342563152313, 0.0497402660548687, 0.07117598503828049, 0.034685466438531876, 0.03757307678461075, 0.04637663811445236], [0.028149226680397987, 0.006627474445849657, 0.009649189189076424, 0.01472978200763464, 0.016015268862247467, 0.004964638501405716, 0.022270992398262024, 0.004066928755491972, 0.012258937582373619, 0.006290400866419077, 0.013614791445434093, 0.013420047238469124, 0.004988821689039469, 0.01560428086668253, 0.052735570818185806, 0.008404477499425411, 0.008628185838460922, 0.003947147633880377, 0.014826220460236073, 0.003075825981795788, 0.0032852385193109512, 0.03219182789325714, 0.004993487149477005, 0.005817024037241936, 0.012261041440069675, 0.058423761278390884, 0.0036919512785971165, 0.002770395250990987, 0.013499732129275799, 0.006200967822223902, 0.003118847729638219, 0.003957283683121204, 0.0026423255912959576, 0.012713623233139515, 0.004194323439151049, 0.012534690089523792, 0.01063451636582613, 0.004856124985963106, 0.014882253482937813, 0.0036231824196875095, 0.01018199697136879, 0.03649166598916054, 0.003122032852843404, 0.008482084609568119, 0.0164847020059824, 0.021939484402537346, 0.008248328231275082, 0.004002139437943697, 0.015223518945276737, 0.005836562253534794, 0.013566100969910622, 0.03960461542010307, 0.0055328477174043655, 0.00897331815212965, 0.1089325100183487, 0.00827556848526001, 0.00902683474123478, 0.02258353866636753, 0.03439580649137497, 0.03581617772579193, 0.01934961788356304, 0.009208076633512974, 0.005008309613913298, 0.06915340572595596], [0.012732869014143944, 0.005153542384505272, 0.009731074795126915, 0.013672314584255219, 0.02167590707540512, 0.005099114961922169, 0.02662358433008194, 0.003977789077907801, 0.01495338324457407, 0.00645087007433176, 0.014421908184885979, 0.014405595138669014, 0.005915821064263582, 0.012347538955509663, 0.05977466702461243, 0.008980270475149155, 0.007471260614693165, 0.004936872515827417, 0.01449290569871664, 0.00407971628010273, 0.004422680474817753, 0.03541563078761101, 0.004249964375048876, 0.005739190615713596, 0.014544015750288963, 0.09632308781147003, 0.0027611267287284136, 0.0034893869888037443, 0.013520551845431328, 0.006315594073385, 0.0034631192684173584, 0.004280513152480125, 0.003096377942711115, 0.010682697407901287, 0.00372262648306787, 0.012444447726011276, 0.013345680199563503, 0.00891097728163004, 0.028935864567756653, 0.003908051643520594, 0.012806197628378868, 0.04200751706957817, 0.003564483253285289, 0.007914384827017784, 0.014730572700500488, 0.021924106404185295, 0.009814079850912094, 0.005961671005934477, 0.015221170149743557, 0.004390710964798927, 0.01033019833266735, 0.03501404821872711, 0.00656181201338768, 0.007612991612404585, 0.07707635313272476, 0.008029158227145672, 0.008212622255086899, 0.0177469402551651, 0.027994316071271896, 0.028993656858801842, 0.011465005576610565, 0.008344309404492378, 0.004415934905409813, 0.04575091227889061, 0.017648249864578247], [0.019253026694059372, 0.005576998461037874, 0.010323828086256981, 0.014613247476518154, 0.015663588419556618, 0.004887180868536234, 0.024013418704271317, 0.00423941807821393, 0.014094083569943905, 0.0057835886254906654, 0.014180907979607582, 0.012859057635068893, 0.00469591561704874, 0.013045796193182468, 0.03615294024348259, 0.005801628343760967, 0.007452945224940777, 0.004255867097526789, 0.012193524278700352, 0.00398012762889266, 0.0034457400906831026, 0.02481466718018055, 0.003945080563426018, 0.005657092202454805, 0.011472627520561218, 0.05497675761580467, 0.0029057436622679234, 0.003104520495980978, 0.011501016095280647, 0.00583183066919446, 0.003367105033248663, 0.005102942232042551, 0.002945256419479847, 0.009614537470042706, 0.0032312211114913225, 0.009523304179310799, 0.011416670866310596, 0.007316771429032087, 0.017519187182188034, 0.003575656795874238, 0.011166182346642017, 0.022412575781345367, 0.003258640179410577, 0.007818900980055332, 0.01200786978006363, 0.016674069687724113, 0.009671696461737156, 0.004795295186340809, 0.013462410308420658, 0.004318644758313894, 0.010231765918433666, 0.03828839585185051, 0.005528192035853863, 0.01033124141395092, 0.07461279630661011, 0.009446444921195507, 0.00643202755600214, 0.013517355546355247, 0.04077818617224693, 0.04049479216337204, 0.012611838057637215, 0.00722779706120491, 0.005926378536969423, 0.04457586258649826, 0.021747734397649765, 0.11832806468009949], [0.01981980726122856, 0.00777242099866271, 0.01342790201306343, 0.01828753389418125, 0.03206145763397217, 0.007020312361419201, 0.03399550914764404, 0.005562136881053448, 0.019657671451568604, 0.007542666047811508, 0.018555741757154465, 0.014109333045780659, 0.007212131749838591, 0.020938053727149963, 0.021917644888162613, 0.006716791074723005, 0.008087217807769775, 0.0034122755751013756, 0.01383484248071909, 0.005568630062043667, 0.004779813811182976, 0.029772579669952393, 0.004310804419219494, 0.0045112622901797295, 0.014656097628176212, 0.04632432386279106, 0.003943724557757378, 0.004727139137685299, 0.016231566667556763, 0.006684159394353628, 0.004078765399754047, 0.007449073251336813, 0.004026283975690603, 0.011609130539000034, 0.004084503278136253, 0.009768284857273102, 0.013373804278671741, 0.008174298331141472, 0.028010737150907516, 0.002940604230388999, 0.01013852283358574, 0.018433285877108574, 0.00376311712898314, 0.0082625113427639, 0.013570652343332767, 0.01905573531985283, 0.012120811268687248, 0.006545338314026594, 0.018447840586304665, 0.003429138334468007, 0.010814493522047997, 0.027966206893324852, 0.007331895641982555, 0.007148453965783119, 0.03259674087166786, 0.004981185309588909, 0.003076103050261736, 0.010004149749875069, 0.0206602830439806, 0.0251601692289114, 0.007438112981617451, 0.00598750589415431, 0.005189069546759129, 0.028450174257159233, 0.015220367349684238, 0.06766960769891739, 0.09158148616552353], [0.01533299870789051, 0.0042402963154017925, 0.008476199582219124, 0.011131350882351398, 0.01692911423742771, 0.005054301582276821, 0.021898815408349037, 0.0035709182266145945, 0.01171468198299408, 0.0051872581243515015, 0.012838413938879967, 0.011789899319410324, 0.0040527465753257275, 0.008464833721518517, 0.04280737787485123, 0.007056002039462328, 0.00742747075855732, 0.003352272557094693, 0.011386646889150143, 0.0033952512312680483, 0.0030234637670218945, 0.023722000420093536, 0.0036643093917518854, 0.0059740724973380566, 0.00903228111565113, 0.05913759768009186, 0.0034469212405383587, 0.0030283937230706215, 0.009077049791812897, 0.006538004148751497, 0.0034696110524237156, 0.007033196277916431, 0.003360538277775049, 0.013762674294412136, 0.0047173695638775826, 0.019650690257549286, 0.013598120771348476, 0.0049562822096049786, 0.014337148517370224, 0.0035699980799108744, 0.012040868401527405, 0.03701033070683479, 0.004520734306424856, 0.015958230942487717, 0.0181483943015337, 0.016163695603609085, 0.007676330395042896, 0.0034687721636146307, 0.010956032201647758, 0.003770251292735338, 0.009195718914270401, 0.023649010807275772, 0.005123113747686148, 0.005637633614242077, 0.08116122335195541, 0.007381033152341843, 0.0075174435041844845, 0.018201230093836784, 0.031324002891778946, 0.02825162373483181, 0.01090195681899786, 0.0075682890601456165, 0.005421341862529516, 0.04021180793642998, 0.00639295531436801, 0.025680935010313988, 0.05105355754494667, 0.07440681755542755], [0.014452585950493813, 0.004656115081161261, 0.009249011054635048, 0.013204926624894142, 0.01548115722835064, 0.004492034204304218, 0.021348442882299423, 0.003453318029642105, 0.012437059544026852, 0.005165901035070419, 0.013685764744877815, 0.010273286141455173, 0.003954821266233921, 0.007904743775725365, 0.02829165942966938, 0.00656514149159193, 0.006505739409476519, 0.003760513151064515, 0.016512272879481316, 0.0032409706618636847, 0.003440145868808031, 0.028905116021633148, 0.003492822637781501, 0.0039654881693422794, 0.012201361358165741, 0.04035591706633568, 0.003190229646861553, 0.0030000845436006784, 0.011787695810198784, 0.006490141618996859, 0.003511841408908367, 0.006232433021068573, 0.0029857398476451635, 0.013379321433603764, 0.006353086791932583, 0.032949142158031464, 0.02368016354739666, 0.00846309307962656, 0.02008643001317978, 0.004852874204516411, 0.01942274160683155, 0.0318174846470356, 0.007796857971698046, 0.033925920724868774, 0.08028154075145721, 0.02116481214761734, 0.004757986404001713, 0.0022903645876795053, 0.00901115033775568, 0.003751093987375498, 0.009926613420248032, 0.018566923215985298, 0.003655878361314535, 0.0058860271237790585, 0.05353328585624695, 0.006257182918488979, 0.003911351785063744, 0.009360909461975098, 0.02752162516117096, 0.025663642212748528, 0.008478476665914059, 0.003871614346280694, 0.0023631565272808075, 0.0200920682400465, 0.004246933851391077, 0.018989553675055504, 0.029626965522766113, 0.03340104594826698, 0.056468237191438675], [0.013796357437968254, 0.004908632021397352, 0.009480173699557781, 0.01189251709729433, 0.01702217012643814, 0.004429460968822241, 0.02092897705733776, 0.0036331673618406057, 0.013003976084291935, 0.004682507831603289, 0.012992010451853275, 0.010367071256041527, 0.004494907334446907, 0.007677028421312571, 0.03909241035580635, 0.005098908208310604, 0.006651913747191429, 0.002931282389909029, 0.011653241701424122, 0.00271219527348876, 0.0029594588559120893, 0.024114301428198814, 0.004212076775729656, 0.004326271824538708, 0.011193634010851383, 0.03582368791103363, 0.0030424417927861214, 0.0027144986670464277, 0.009762314148247242, 0.006047739181667566, 0.003471620613709092, 0.004299054387956858, 0.0022751614451408386, 0.014217792078852654, 0.0033341054804623127, 0.015910854563117027, 0.008832662366330624, 0.0056400178000330925, 0.01903289183974266, 0.0027192006818950176, 0.009604507125914097, 0.017107145860791206, 0.004500917159020901, 0.016564231365919113, 0.044649720191955566, 0.08827996253967285, 0.004963928833603859, 0.0031887716613709927, 0.010026518255472183, 0.0031741366256028414, 0.009712890721857548, 0.019574826583266258, 0.0045163314789533615, 0.005273911170661449, 0.06377050280570984, 0.005223017185926437, 0.0038599141407757998, 0.011150532402098179, 0.023096377030014992, 0.022285571321845055, 0.009597374126315117, 0.005662926007062197, 0.0032875624019652605, 0.026180099695920944, 0.007567915134131908, 0.020818699151277542, 0.029614508152008057, 0.03772725164890289, 0.039135754108428955, 0.058505501598119736]]},\n",
+              "                data: {'tokens': [{'token': 'در', 'token_id': 589, 'type': 'input', 'value': '0.12459614', 'position': 0}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'value': '0.05899072', 'position': 1}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'input', 'value': '0.112841696', 'position': 2}, {'token': ' شگفت', 'token_id': 3844, 'type': 'input', 'value': '0.16566701', 'position': 3}, {'token': ' انگیز', 'token_id': 5904, 'type': 'input', 'value': '0.18307066', 'position': 4}, {'token': '،', 'token_id': 305, 'type': 'input', 'value': '0.0696605', 'position': 5}, {'token': ' پژوهشگران', 'token_id': 4579, 'type': 'input', 'value': '0.2851732', 'position': 6}, {'token': ' توانستند', 'token_id': 7183, 'type': 'output', 'value': '0', 'position': 7}, {'token': ' یک', 'token_id': 367, 'type': 'output', 'value': '0', 'position': 8}, {'token': ' مولکول', 'token_id': 7053, 'type': 'output', 'value': '0', 'position': 9}, {'token': ' RNA', 'token_id': 16789, 'type': 'output', 'value': '0', 'position': 10}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 11}, {'token': ' ویروس', 'token_id': 1816, 'type': 'output', 'value': '0', 'position': 12}, {'token': ' زیکا', 'token_id': 25375, 'type': 'output', 'value': '0', 'position': 13}, {'token': ' را', 'token_id': 330, 'type': 'output', 'value': '0', 'position': 14}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 15}, {'token': ' فردی', 'token_id': 2730, 'type': 'output', 'value': '0', 'position': 16}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 17}, {'token': ' فرد', 'token_id': 1113, 'type': 'output', 'value': '0', 'position': 18}, {'token': ' دیگری', 'token_id': 1145, 'type': 'output', 'value': '0', 'position': 19}, {'token': ' منتقل', 'token_id': 2923, 'type': 'output', 'value': '0', 'position': 20}, {'token': ' کنند', 'token_id': 689, 'type': 'output', 'value': '0', 'position': 21}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 22}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 23}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'output', 'value': '0', 'position': 24}, {'token': ' عجیب', 'token_id': 3595, 'type': 'output', 'value': '0', 'position': 25}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 26}, {'token': ' تقریبا', 'token_id': 1985, 'type': 'output', 'value': '0', 'position': 27}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 28}, {'token': ' میانه', 'token_id': 4720, 'type': 'output', 'value': '0', 'position': 29}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 30}, {'token': 'ی', 'token_id': 269, 'type': 'output', 'value': '0', 'position': 31}, {'token': ' سال', 'token_id': 415, 'type': 'output', 'value': '0', 'position': 32}, {'token': ' 2015', 'token_id': 9109, 'type': 'output', 'value': '0', 'position': 33}, {'token': ' رخ', 'token_id': 2130, 'type': 'output', 'value': '0', 'position': 34}, {'token': ' داده', 'token_id': 658, 'type': 'output', 'value': '0', 'position': 35}, {'token': ' بود', 'token_id': 390, 'type': 'output', 'value': '0', 'position': 36}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 37}, {'token': ' بسیار', 'token_id': 674, 'type': 'output', 'value': '0', 'position': 38}, {'token': ' جالب', 'token_id': 2351, 'type': 'output', 'value': '0', 'position': 39}, {'token': ' توجه', 'token_id': 772, 'type': 'output', 'value': '0', 'position': 40}, {'token': ' است', 'token_id': 329, 'type': 'output', 'value': '0', 'position': 41}, {'token': '؛', 'token_id': 556, 'type': 'output', 'value': '0', 'position': 42}, {'token': ' زیرا', 'token_id': 1846, 'type': 'output', 'value': '0', 'position': 43}, {'token': ' تا', 'token_id': 399, 'type': 'output', 'value': '0', 'position': 44}, {'token': ' پیش', 'token_id': 495, 'type': 'output', 'value': '0', 'position': 45}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 46}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 47}, {'token': ' تصور', 'token_id': 2826, 'type': 'output', 'value': '0', 'position': 48}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 49}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 50}, {'token': 'شد', 'token_id': 424, 'type': 'output', 'value': '0', 'position': 51}, {'token': ' ویروس', 'token_id': 1816, 'type': 'output', 'value': '0', 'position': 52}, {'token': ' زیکا', 'token_id': 25375, 'type': 'output', 'value': '0', 'position': 53}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 54}, {'token': ' یک', 'token_id': 367, 'type': 'output', 'value': '0', 'position': 55}, {'token': ' پشه', 'token_id': 14891, 'type': 'output', 'value': '0', 'position': 56}, {'token': ' نشئت', 'token_id': 35308, 'type': 'output', 'value': '0', 'position': 57}, {'token': ' گرفته', 'token_id': 792, 'type': 'output', 'value': '0', 'position': 58}, {'token': ' باشد', 'token_id': 577, 'type': 'output', 'value': '0', 'position': 59}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 60}, {'token': ' اما', 'token_id': 492, 'type': 'output', 'value': '0', 'position': 61}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 62}, {'token': ' صورت', 'token_id': 649, 'type': 'output', 'value': '0', 'position': 63}, {'token': ' صحت', 'token_id': 6083, 'type': 'output', 'value': '0', 'position': 64}, {'token': ' چنین', 'token_id': 1267, 'type': 'output', 'value': '0', 'position': 65}, {'token': ' چیزی', 'token_id': 1426, 'type': 'output', 'value': '0', 'position': 66}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 67}, {'token': ' دانشمندان', 'token_id': 3612, 'type': 'output', 'value': '0', 'position': 68}, {'token': ' قادر', 'token_id': 2306, 'type': 'output', 'value': '0', 'position': 69}, {'token': ' بودند', 'token_id': 1146, 'type': 'output', 'value': '0', 'position': 70}], 'attributions': [[0.12459614127874374, 0.0589907206594944, 0.11284169554710388, 0.16566701233386993, 0.18307065963745117, 0.0696604996919632, 0.2851732075214386], [0.2529815137386322, 0.04535181075334549, 0.07425308227539062, 0.09567464143037796, 0.10514038056135178, 0.03693828359246254, 0.16995692253112793, 0.21970336139202118], [0.15232427418231964, 0.05558961629867554, 0.06487555801868439, 0.10506639629602432, 0.09358786046504974, 0.03876924887299538, 0.2239697426557541, 0.18994463980197906, 0.07587271928787231], [0.10416479408740997, 0.03021611087024212, 0.04603811353445053, 0.07484112679958344, 0.08596987277269363, 0.022690078243613243, 0.13322341442108154, 0.08129703998565674, 0.03362403064966202, 0.38793545961380005], [0.04880847781896591, 0.0231622401624918, 0.03712782263755798, 0.05732569098472595, 0.0507839098572731, 0.017206469550728798, 0.0895972028374672, 0.0746329203248024, 0.016689589247107506, 0.15205365419387817, 0.4326120615005493], [0.0784013420343399, 0.02447136677801609, 0.037635840475559235, 0.04916936904191971, 0.058922186493873596, 0.038343898952007294, 0.089069664478302, 0.08586148917675018, 0.026474889367818832, 0.10156935453414917, 0.35797402262687683, 0.05210665613412857], [0.07602772116661072, 0.025262637063860893, 0.03331468999385834, 0.048916853964328766, 0.04952231049537659, 0.02154785580933094, 0.06093193590641022, 0.05077765882015228, 0.01922646164894104, 0.08694818615913391, 0.2387099266052246, 0.031140197068452835, 0.2576735317707062], [0.07080917060375214, 0.02349696308374405, 0.02228398248553276, 0.03310896456241608, 0.03559548407793045, 0.022395271807909012, 0.05328044295310974, 0.04272511228919029, 0.016377324238419533, 0.06443307548761368, 0.10022883862257004, 0.024790387600660324, 0.07003143429756165, 0.4204435646533966], [0.099708192050457, 0.023978274315595627, 0.034844573587179184, 0.04499518871307373, 0.045593712478876114, 0.02105763368308544, 0.07214769721031189, 0.05793411657214165, 0.018171433359384537, 0.08049940317869186, 0.16231487691402435, 0.018503766506910324, 0.1419326663017273, 0.13660404086112976, 0.0417143888771534], [0.05759957432746887, 0.020180504769086838, 0.025413943454623222, 0.035093825310468674, 0.03478282317519188, 0.021151674911379814, 0.05764422565698624, 0.05058042332530022, 0.014423484914004803, 0.06032995507121086, 0.12792828679084778, 0.017272597178816795, 0.1163620725274086, 0.26477640867233276, 0.03721826896071434, 0.05924198403954506], [0.04383831098675728, 0.016796182841062546, 0.024505162611603737, 0.036710627377033234, 0.03142582252621651, 0.01769358664751053, 0.05913127586245537, 0.05890759080648422, 0.01484772004187107, 0.051242753863334656, 0.09331042319536209, 0.013932371512055397, 0.08884351700544357, 0.17413154244422913, 0.032183922827243805, 0.03885793685913086, 0.20364128053188324], [0.04513881728053093, 0.018431395292282104, 0.02319537103176117, 0.03343474119901657, 0.030762281268835068, 0.017931196838617325, 0.05714104697108269, 0.053488340228796005, 0.014715325087308884, 0.051865167915821075, 0.09840762615203857, 0.016507193446159363, 0.06383009999990463, 0.14852923154830933, 0.030167927965521812, 0.038192927837371826, 0.19447314739227295, 0.06378810852766037], [0.040469735860824585, 0.020507147535681725, 0.02554406225681305, 0.04060496389865875, 0.03481050208210945, 0.014785351231694221, 0.05158572271466255, 0.04979085922241211, 0.01281694881618023, 0.04395487159490585, 0.09318181872367859, 0.012017556466162205, 0.04689127206802368, 0.17374995350837708, 0.02248011715710163, 0.020159700885415077, 0.1078588217496872, 0.052611175924539566, 0.13617952167987823], [0.05505736172199249, 0.01965588517487049, 0.02387665957212448, 0.03233099728822708, 0.034954626113176346, 0.017750883474946022, 0.050370726734399796, 0.05974967032670975, 0.01625778153538704, 0.06168689951300621, 0.11363811790943146, 0.014419186860322952, 0.09191948175430298, 0.1085553914308548, 0.022623008117079735, 0.02013479359447956, 0.05888644605875015, 0.028962016105651855, 0.06781131774187088, 0.10135869681835175], [0.06407136470079422, 0.022351540625095367, 0.03516478091478348, 0.05461277440190315, 0.056863728910684586, 0.019441725686192513, 0.06864368915557861, 0.10735636204481125, 0.010044955648481846, 0.03931380808353424, 0.06271376460790634, 0.010340537875890732, 0.062413979321718216, 0.09924459457397461, 0.026679720729589462, 0.00952533632516861, 0.03102688118815422, 0.01206499058753252, 0.02149616740643978, 0.02330481819808483, 0.16332441568374634], [0.06293593347072601, 0.023719172924757004, 0.04484096169471741, 0.04689894616603851, 0.05361379683017731, 0.02099642902612686, 0.08006977289915085, 0.07615523040294647, 0.013140060938894749, 0.03982928767800331, 0.0629565492272377, 0.014239848591387272, 0.04152067005634308, 0.155813068151474, 0.0213130135089159, 0.010399339720606804, 0.032981447875499725, 0.0117741534486413, 0.026547808200120926, 0.020156988874077797, 0.06716983765363693, 0.07292769104242325], [0.14208495616912842, 0.02269715815782547, 0.034101322293281555, 0.05120595172047615, 0.053267743438482285, 0.017664063721895218, 0.08289331942796707, 0.09443490207195282, 0.013874845579266548, 0.05693495646119118, 0.0764387920498848, 0.01666870526969433, 0.032783348113298416, 0.10944703221321106, 0.010075638070702553, 0.007890261709690094, 0.02716200239956379, 0.008090787567198277, 0.0212688148021698, 0.014299334958195686, 0.03337441757321358, 0.03496061637997627, 0.03838104009628296], [0.05541360378265381, 0.024189850315451622, 0.06455729901790619, 0.040177155286073685, 0.04015693813562393, 0.01708126813173294, 0.0738920345902443, 0.0610194057226181, 0.014303836971521378, 0.06944752484560013, 0.09767015278339386, 0.016407471150159836, 0.044368959963321686, 0.07603656500577927, 0.01255666371434927, 0.009707731194794178, 0.03939976915717125, 0.008869394659996033, 0.022745223715901375, 0.01783454790711403, 0.055060580372810364, 0.0509452149271965, 0.03654804080724716, 0.051610734313726425], [0.07795809209346771, 0.02718258649110794, 0.08559254556894302, 0.13590076565742493, 0.094501793384552, 0.0123142683878541, 0.05801397189497948, 0.04178117588162422, 0.007677602116018534, 0.027785930782556534, 0.052316103130578995, 0.0100296251475811, 0.02190161496400833, 0.08282043784856796, 0.008096480742096901, 0.0055265529081225395, 0.017123814672231674, 0.004878033883869648, 0.015107635408639908, 0.01096715871244669, 0.027464304119348526, 0.025326890870928764, 0.02076668106019497, 0.027756787836551666, 0.1012091264128685], [0.09031327813863754, 0.022765565663576126, 0.04793236032128334, 0.06000019982457161, 0.06944668292999268, 0.01726400852203369, 0.06564363837242126, 0.04977063462138176, 0.009256020188331604, 0.032702863216400146, 0.04942885786294937, 0.011061348952353, 0.027711885049939156, 0.07995136827230453, 0.009570164605975151, 0.007153091486543417, 0.019512630999088287, 0.0065969545394182205, 0.019590677693486214, 0.011801597662270069, 0.025472331792116165, 0.020733816549181938, 0.02587086893618107, 0.017852462828159332, 0.04883924871683121, 0.1537574827671051], [0.03608781099319458, 0.018945923075079918, 0.042487792670726776, 0.04656713828444481, 0.04769504442811012, 0.014906643889844418, 0.05467991158366203, 0.05156176537275314, 0.011280180886387825, 0.036731064319610596, 0.053536560386419296, 0.012793175876140594, 0.02740049548447132, 0.10650606453418732, 0.013503862544894218, 0.013049459084868431, 0.02800799161195755, 0.011115698143839836, 0.02049490064382553, 0.016941139474511147, 0.03509649261832237, 0.04442191496491432, 0.023368433117866516, 0.016289599239826202, 0.05264139175415039, 0.12534548342227936, 0.03854404389858246], [0.03995322808623314, 0.015530649572610855, 0.03790297731757164, 0.03939276188611984, 0.04204639792442322, 0.01319812424480915, 0.05220472440123558, 0.054400671273469925, 0.009319848380982876, 0.02958216704428196, 0.051345694810152054, 0.011860890313982964, 0.02289271354675293, 0.08257012069225311, 0.010382406413555145, 0.010675907135009766, 0.029997358098626137, 0.009009827859699726, 0.01862887293100357, 0.016876250505447388, 0.03283550590276718, 0.030682550743222237, 0.023874470964074135, 0.025093650445342064, 0.05740986764431, 0.08162907510995865, 0.02811415120959282, 0.12258915603160858], [0.03468536585569382, 0.01420165877789259, 0.03211149200797081, 0.032070159912109375, 0.04905363917350769, 0.012988066300749779, 0.06332265585660934, 0.05103076249361038, 0.011850827373564243, 0.037792179733514786, 0.057034771889448166, 0.009326977655291557, 0.03012782149016857, 0.11473535746335983, 0.011316077783703804, 0.010254425927996635, 0.02849821373820305, 0.013318863697350025, 0.025286268442869186, 0.016898272559046745, 0.027275821194052696, 0.01847984828054905, 0.02069409005343914, 0.012561870738863945, 0.042942970991134644, 0.07018674165010452, 0.019638678058981895, 0.09062091261148453, 0.04169521480798721], [0.053866248577833176, 0.012108851224184036, 0.028179455548524857, 0.03542815148830414, 0.04263324663043022, 0.010220766067504883, 0.03903697431087494, 0.029196834191679955, 0.007950103841722012, 0.02492797188460827, 0.04748152196407318, 0.009603161364793777, 0.031118594110012054, 0.13128842413425446, 0.008011515252292156, 0.007559305988252163, 0.026399195194244385, 0.007308554369956255, 0.017988214269280434, 0.011886168271303177, 0.019265171140432358, 0.013609516434371471, 0.01590442657470703, 0.007468835450708866, 0.029029574245214462, 0.05243295803666115, 0.019962487742304802, 0.04037617892026901, 0.025904664769768715, 0.19385288655757904], [0.04599115252494812, 0.013908489607274532, 0.02483011595904827, 0.035999953746795654, 0.10849549621343613, 0.015582884661853313, 0.063108891248703, 0.04242251068353653, 0.008760645985603333, 0.029479360207915306, 0.049082182347774506, 0.014809329062700272, 0.02198493666946888, 0.08485385030508041, 0.009264818392693996, 0.007419924717396498, 0.019426025450229645, 0.008494928479194641, 0.019555198028683662, 0.013761098496615887, 0.020577505230903625, 0.02030400186777115, 0.019029656425118446, 0.008807580918073654, 0.02152964286506176, 0.035210996866226196, 0.01037800032645464, 0.025799641385674477, 0.017128532752394676, 0.11914613842964172, 0.06485648453235626], [0.024040933698415756, 0.009581975638866425, 0.022049367427825928, 0.024067798629403114, 0.026212329044938087, 0.009515766985714436, 0.03329095244407654, 0.029496869072318077, 0.006518335081636906, 0.022639969363808632, 0.03966492414474487, 0.00898873433470726, 0.0294137392193079, 0.11951640248298645, 0.009375058114528656, 0.008341385051608086, 0.025370826944708824, 0.010073949582874775, 0.014459243975579739, 0.010891355574131012, 0.019398299977183342, 0.015723804011940956, 0.022033801302313805, 0.008866447024047375, 0.028992842882871628, 0.04630151391029358, 0.02575969509780407, 0.03760502487421036, 0.01851644180715084, 0.20524755120277405, 0.011715947650372982, 0.07632868736982346], [0.03767366707324982, 0.015039918944239616, 0.02620927058160305, 0.04772048071026802, 0.09031621366739273, 0.011375864036381245, 0.056250229477882385, 0.048186443746089935, 0.009212073870003223, 0.03062625043094158, 0.048203323036432266, 0.008911460638046265, 0.025398271158337593, 0.146060511469841, 0.008858838118612766, 0.006686085369437933, 0.021207423880696297, 0.006751825101673603, 0.020831845700740814, 0.012697103433310986, 0.01959266886115074, 0.022235363721847534, 0.024913538247346878, 0.006601069588214159, 0.01883990690112114, 0.02835673652589321, 0.010706198401749134, 0.019131556153297424, 0.010529689490795135, 0.07048661261796951, 0.0111683439463377, 0.02779192291200161, 0.05142926424741745], [0.03604169189929962, 0.011668023653328419, 0.034948285669088364, 0.03281804546713829, 0.03130565583705902, 0.010447677224874496, 0.04213670641183853, 0.02700139209628105, 0.0065635014325380325, 0.021353688091039658, 0.03437703102827072, 0.007233802694827318, 0.02078537829220295, 0.07595853507518768, 0.007737737149000168, 0.0064164442010223866, 0.02091761864721775, 0.006411997601389885, 0.016948409378528595, 0.010640245862305164, 0.018127528950572014, 0.0154121620580554, 0.014997366815805435, 0.012973747216165066, 0.04698353633284569, 0.04701879248023033, 0.016902415081858635, 0.033057134598493576, 0.009617011062800884, 0.061363425105810165, 0.007322527468204498, 0.029062729328870773, 0.04147661104798317, 0.18397320806980133], [0.035244036465883255, 0.013265511021018028, 0.029235417023301125, 0.024144329130649567, 0.028328241780400276, 0.009090706706047058, 0.032675858587026596, 0.02889280766248703, 0.005860803183168173, 0.019728869199752808, 0.030791033059358597, 0.008044430054724216, 0.0166948102414608, 0.05510980635881424, 0.007309436798095703, 0.0058751716278493404, 0.0141866160556674, 0.005389383994042873, 0.014450306072831154, 0.009253846481442451, 0.016972966492176056, 0.01589118503034115, 0.015533221885561943, 0.009026098996400833, 0.03414662182331085, 0.046254731714725494, 0.015892591327428818, 0.02647286280989647, 0.009996041655540466, 0.050081752240657806, 0.006090652663260698, 0.021127454936504364, 0.027765506878495216, 0.10648858547210693, 0.20468828082084656], [0.027601487934589386, 0.011068012565374374, 0.023422006517648697, 0.021514328196644783, 0.028658172115683556, 0.012046508491039276, 0.03697385638952255, 0.07035086303949356, 0.006737875286489725, 0.01986510679125786, 0.03480121120810509, 0.00996313150972128, 0.015486272983253002, 0.05861137434840202, 0.009244811721146107, 0.005739608313888311, 0.016340889036655426, 0.00562829477712512, 0.01504586823284626, 0.011982698924839497, 0.027964511886239052, 0.05135392025113106, 0.015523246489465237, 0.011201952584087849, 0.026242854073643684, 0.04561332240700722, 0.01202515047043562, 0.016214830800890923, 0.006935405544936657, 0.04012409970164299, 0.0058925217017531395, 0.020242540165781975, 0.019840287044644356, 0.08222771435976028, 0.10025627911090851, 0.07725901156663895], [0.05833694711327553, 0.014158246107399464, 0.02876315824687481, 0.033423684537410736, 0.04076646640896797, 0.01844620518386364, 0.043657321482896805, 0.03732679411768913, 0.008903338573873043, 0.02446647360920906, 0.03982466831803322, 0.013412076979875565, 0.02048288658261299, 0.07103263586759567, 0.009610350243747234, 0.0073249158449471, 0.016790714114904404, 0.006938905455172062, 0.013930238783359528, 0.009098909795284271, 0.018728679046034813, 0.021245166659355164, 0.01960105262696743, 0.011922354809939861, 0.03370649740099907, 0.061837006360292435, 0.02578432857990265, 0.01772122085094452, 0.00579717056825757, 0.04632611200213432, 0.0065526640973985195, 0.025040794163942337, 0.011512059718370438, 0.06517720967531204, 0.04201703518629074, 0.032564904540777206, 0.03777075186371803], [0.028437528759241104, 0.012858198024332523, 0.029058517888188362, 0.03170205280184746, 0.04011141508817673, 0.013798587024211884, 0.04584014415740967, 0.040225908160209656, 0.007829546928405762, 0.029606079682707787, 0.04365178570151329, 0.011106550693511963, 0.025627167895436287, 0.08597414940595627, 0.010356421582400799, 0.008077251724898815, 0.019075661897659302, 0.007137411739677191, 0.018252382054924965, 0.012172051705420017, 0.02340644970536232, 0.023407790809869766, 0.01955839805305004, 0.01104331761598587, 0.04047297313809395, 0.07283547520637512, 0.016371440142393112, 0.016498100012540817, 0.007379240822046995, 0.03843194618821144, 0.005098860245198011, 0.014634750783443451, 0.009548225440084934, 0.04679559916257858, 0.0391664057970047, 0.02607959881424904, 0.04156367853283882, 0.026808975264430046], [0.029285229742527008, 0.01536040473729372, 0.03850794956088066, 0.06648729741573334, 0.04815235361456871, 0.009091353975236416, 0.03638817369937897, 0.03172880783677101, 0.00734717445448041, 0.02415931411087513, 0.035243622958660126, 0.007798622362315655, 0.02076129987835884, 0.05787219479680061, 0.006526454817503691, 0.006237529218196869, 0.01621832884848118, 0.0051058027893304825, 0.014551497995853424, 0.011892206035554409, 0.0233645997941494, 0.016932757571339607, 0.012282217852771282, 0.01096659991890192, 0.04553016647696495, 0.07408188283443451, 0.012605915777385235, 0.016059326007962227, 0.005145110655575991, 0.029473496600985527, 0.0038962368853390217, 0.017446832731366158, 0.010241246782243252, 0.039750322699546814, 0.042794644832611084, 0.02511938475072384, 0.024909203872084618, 0.018581561744213104, 0.08210281282663345], [0.025081146508455276, 0.010696264915168285, 0.026332659646868706, 0.03884657844901085, 0.026304462924599648, 0.010357419028878212, 0.03634653985500336, 0.022793494164943695, 0.005623409058898687, 0.018504543229937553, 0.024887459352612495, 0.006949122529476881, 0.011938598938286304, 0.03469231352210045, 0.006190435495227575, 0.004945534281432629, 0.01227620430290699, 0.004502475261688232, 0.011648940853774548, 0.00798347033560276, 0.015596412122249603, 0.013717025518417358, 0.014615754596889019, 0.009478295221924782, 0.028448326513171196, 0.07259123772382736, 0.011988162063062191, 0.015080996789038181, 0.0038183259312063456, 0.02638481929898262, 0.005372445099055767, 0.01182058546692133, 0.009235185571014881, 0.03601161763072014, 0.028316838666796684, 0.017553744837641716, 0.021606391295790672, 0.012329785153269768, 0.06050562113523483, 0.2386273890733719], [0.02057763747870922, 0.008408510126173496, 0.019716160371899605, 0.02914506196975708, 0.02360595017671585, 0.010037314146757126, 0.03197287768125534, 0.03232477605342865, 0.006157880648970604, 0.016859527677297592, 0.026519006118178368, 0.007919896394014359, 0.013240357860922813, 0.045707494020462036, 0.007345430552959442, 0.005190914496779442, 0.013738654553890228, 0.00495350593701005, 0.011897091753780842, 0.009101996198296547, 0.01672924868762493, 0.013196046464145184, 0.017207838594913483, 0.010146953165531158, 0.03055487386882305, 0.045819640159606934, 0.013989236205816269, 0.017307300120592117, 0.006032575853168964, 0.03534785658121109, 0.00826504360884428, 0.0166028942912817, 0.013835528865456581, 0.06889394670724869, 0.04260680824518204, 0.031218094751238823, 0.04255964607000351, 0.013244054280221462, 0.0362643301486969, 0.10670078545808792, 0.06905720382928848], [0.027713503688573837, 0.011387662030756474, 0.02158042974770069, 0.023335345089435577, 0.04097602143883705, 0.0111611969769001, 0.05226196348667145, 0.03983861207962036, 0.008838998153805733, 0.026737971231341362, 0.04105883836746216, 0.009721953421831131, 0.019474808126688004, 0.06834874302148819, 0.008369406685233116, 0.007217615842819214, 0.018741220235824585, 0.006693869363516569, 0.01839442364871502, 0.012550384737551212, 0.018615489825606346, 0.014534372836351395, 0.018478751182556152, 0.00804912205785513, 0.025074439123272896, 0.033902447670698166, 0.013316688127815723, 0.021913520991802216, 0.00555050652474165, 0.038733869791030884, 0.008567829616367817, 0.030478263273835182, 0.013545759953558445, 0.06414539366960526, 0.028259573504328728, 0.012089774012565613, 0.016408400610089302, 0.012074450962245464, 0.02035512961447239, 0.04908019304275513, 0.03707296401262283, 0.035350143909454346], [0.02219082973897457, 0.008725222200155258, 0.013558315113186836, 0.0173980500549078, 0.04555784538388252, 0.00839065108448267, 0.06838790327310562, 0.024586983025074005, 0.006340003572404385, 0.01962820440530777, 0.027249397709965706, 0.006376071833074093, 0.014000446535646915, 0.04841587692499161, 0.006827497389167547, 0.004100009799003601, 0.012960967607796192, 0.0036829225718975067, 0.012688116170465946, 0.009065003134310246, 0.015085579827427864, 0.010141848586499691, 0.012759252451360226, 0.005907940212637186, 0.015196302905678749, 0.027661656960844994, 0.006369775626808405, 0.016147207468748093, 0.003769477130845189, 0.02753061056137085, 0.011973530985414982, 0.05581014230847359, 0.007927964441478252, 0.12062345445156097, 0.02108742482960224, 0.009680798277258873, 0.012278851121664047, 0.006784271448850632, 0.014518837444484234, 0.04924531280994415, 0.03515886887907982, 0.022693544626235962, 0.11151700466871262], [0.02504323050379753, 0.00969410128891468, 0.016988418996334076, 0.019870877265930176, 0.026428934186697006, 0.00892195850610733, 0.0374847836792469, 0.026577165350317955, 0.006088499911129475, 0.025226309895515442, 0.05558403953909874, 0.007607693783938885, 0.022826915606856346, 0.1231093779206276, 0.006157378200441599, 0.005849852226674557, 0.02603822574019432, 0.004318992141634226, 0.012091124430298805, 0.008141692727804184, 0.021251723170280457, 0.010085966438055038, 0.010824163444340229, 0.007767914794385433, 0.018027404323220253, 0.02872278168797493, 0.008219948038458824, 0.017761358991265297, 0.006005352828651667, 0.03565627336502075, 0.005344239063560963, 0.018114101141691208, 0.014003239572048187, 0.04256901144981384, 0.018592247739434242, 0.010186499916017056, 0.01096621248871088, 0.00427996227517724, 0.011803898960351944, 0.044851914048194885, 0.02472340129315853, 0.014337478205561638, 0.03753594309091568, 0.10431939363479614], [0.024230461567640305, 0.009675081819295883, 0.019172538071870804, 0.021206792443990707, 0.032636355608701706, 0.006988095585256815, 0.045105427503585815, 0.036215074360370636, 0.007050504442304373, 0.02513193152844906, 0.03693537414073944, 0.006251859944313765, 0.0196780264377594, 0.0728691890835762, 0.009222671389579773, 0.005548407789319754, 0.016160039231181145, 0.004879340063780546, 0.014870191924273968, 0.01112388726323843, 0.01774810068309307, 0.012725344859063625, 0.02041388675570488, 0.006519473157823086, 0.022142156958580017, 0.03487618267536163, 0.008555649779736996, 0.019976738840341568, 0.005759235471487045, 0.03858894109725952, 0.0059962705709040165, 0.0218976903706789, 0.016714246943593025, 0.07101621478796005, 0.024621780961751938, 0.011118249036371708, 0.012045089155435562, 0.004812785889953375, 0.011757279746234417, 0.029511116445064545, 0.016946811228990555, 0.01150855328887701, 0.028827309608459473, 0.07808324694633484, 0.04288638383150101], [0.02812175638973713, 0.01158537995070219, 0.02084067091345787, 0.025751136243343353, 0.03269927203655243, 0.008018809370696545, 0.038325175642967224, 0.02868252992630005, 0.007170676253736019, 0.020321615040302277, 0.031764958053827286, 0.007407699711620808, 0.017909754067659378, 0.06645021587610245, 0.010611985810101032, 0.005245007108896971, 0.013611900620162487, 0.00461521465331316, 0.012834100052714348, 0.009187111631035805, 0.01620488613843918, 0.011454823426902294, 0.0173179991543293, 0.005256269127130508, 0.01944746822118759, 0.025447966530919075, 0.007920621894299984, 0.017212385311722755, 0.005243086721748114, 0.03426262363791466, 0.018514389172196388, 0.017513932660222054, 0.01602586917579174, 0.050744712352752686, 0.018508480861783028, 0.009496930986642838, 0.012465178966522217, 0.005057826172560453, 0.011942282319068909, 0.028276558965444565, 0.018484629690647125, 0.010386194102466106, 0.023789165541529655, 0.061626192182302475, 0.045663416385650635, 0.09058116376399994], [0.027811458334326744, 0.008201086893677711, 0.015917165204882622, 0.016584627330303192, 0.01877986639738083, 0.00747892539948225, 0.03416436165571213, 0.027171026915311813, 0.005287014879286289, 0.018251553177833557, 0.029317893087863922, 0.007057914510369301, 0.021151995286345482, 0.10540813207626343, 0.005714257713407278, 0.02476802095770836, 0.011111817322671413, 0.006884687580168247, 0.00963854230940342, 0.00788890477269888, 0.016061754897236824, 0.008526066318154335, 0.01294788159430027, 0.005716969259083271, 0.016330888494849205, 0.02159951813519001, 0.008624372072517872, 0.014169714413583279, 0.004712936468422413, 0.03461718559265137, 0.007561220321804285, 0.016577744856476784, 0.017899302765727043, 0.06271903961896896, 0.023954985663294792, 0.01298450492322445, 0.014003419317305088, 0.006770739331841469, 0.010458176024258137, 0.022128786891698837, 0.015475043095648289, 0.009323101490736008, 0.02251555025577545, 0.06171436980366707, 0.02271157316863537, 0.08981070667505264, 0.03149521350860596], [0.034403372555971146, 0.011623941361904144, 0.02041550725698471, 0.02791854925453663, 0.025889655575156212, 0.010045964270830154, 0.04325075075030327, 0.02995152957737446, 0.007916901260614395, 0.02983730472624302, 0.052953727543354034, 0.008830579929053783, 0.024166038259863853, 0.09476833045482635, 0.006277214270085096, 0.008307760581374168, 0.017546890303492546, 0.004592827055603266, 0.009802861139178276, 0.006623324006795883, 0.029474740847945213, 0.010343613103032112, 0.010972361080348492, 0.014496462419629097, 0.015153986401855946, 0.027309387922286987, 0.008804927580058575, 0.010557379573583603, 0.004547336138784885, 0.025207342579960823, 0.0063643609173595905, 0.011968705803155899, 0.013777375221252441, 0.04222343862056732, 0.022280171513557434, 0.007290498353540897, 0.009069586172699928, 0.005051426123827696, 0.010351640172302723, 0.027557963505387306, 0.015767009928822517, 0.011153211817145348, 0.019338298588991165, 0.050397682934999466, 0.01721218228340149, 0.05701940134167671, 0.011913727968931198, 0.029272815212607384], [0.018258268013596535, 0.007290055975317955, 0.012981018982827663, 0.01735704205930233, 0.01827934756875038, 0.005982641596347094, 0.0325055755674839, 0.022229786962270737, 0.006327094975858927, 0.017403272911906242, 0.02990536205470562, 0.005576396360993385, 0.020101632922887802, 0.054860904812812805, 0.004468329716473818, 0.006608421448618174, 0.01198847871273756, 0.003620073664933443, 0.009208772331476212, 0.007226428482681513, 0.027357110753655434, 0.008479917421936989, 0.008653385564684868, 0.012876119464635849, 0.014150038361549377, 0.02120230719447136, 0.00621135625988245, 0.01062352117151022, 0.0035819862969219685, 0.01733824983239174, 0.004828950390219688, 0.010421257466077805, 0.0076513285748660564, 0.022321635857224464, 0.016678504645824432, 0.006898232735693455, 0.006990536581724882, 0.003693764563649893, 0.00851915217936039, 0.02567405439913273, 0.013018470257520676, 0.0075001041404902935, 0.01557284314185381, 0.04480397701263428, 0.01368495263159275, 0.06458009779453278, 0.02027972787618637, 0.06954848021268845, 0.19468100368976593], [0.05826881527900696, 0.0094884829595685, 0.014219020493328571, 0.03258349373936653, 0.04460630193352699, 0.009473326615989208, 0.023432740941643715, 0.019895503297448158, 0.005379727575927973, 0.016232594847679138, 0.02493196912109852, 0.009224793873727322, 0.021287916228175163, 0.06416194140911102, 0.008032456040382385, 0.007411929313093424, 0.011156977154314518, 0.006839051377028227, 0.009744576178491116, 0.007939289323985577, 0.03208569064736366, 0.009250571019947529, 0.011769198812544346, 0.005690636113286018, 0.008405644446611404, 0.014799166470766068, 0.00641009584069252, 0.008579844608902931, 0.004705409053713083, 0.020795971155166626, 0.015497417189180851, 0.011856567114591599, 0.007362247910350561, 0.03432301804423332, 0.017653679475188255, 0.009352926164865494, 0.016036922112107277, 0.008900556713342667, 0.00726683996617794, 0.017865711823105812, 0.015946680679917336, 0.02160886861383915, 0.018927253782749176, 0.028972143307328224, 0.014983744360506535, 0.02484077587723732, 0.012426158413290977, 0.016170967370271683, 0.078261598944664, 0.09494280070066452], [0.015201964415609837, 0.007068500854074955, 0.011724704876542091, 0.01374205481261015, 0.0463721863925457, 0.00706509780138731, 0.055827297270298004, 0.026116088032722473, 0.005737558472901583, 0.015799781307578087, 0.02364811673760414, 0.0065473453141748905, 0.011907107196748257, 0.03806501254439354, 0.004976955242455006, 0.005470470990985632, 0.011670357547700405, 0.0038845378439873457, 0.010206630453467369, 0.007996639236807823, 0.013032062910497189, 0.009925971738994122, 0.011535881087183952, 0.007890856824815273, 0.012254010885953903, 0.019813723862171173, 0.004687055014073849, 0.01238082442432642, 0.0039427499286830425, 0.021017994731664658, 0.014986993744969368, 0.04781002551317215, 0.0077330972999334335, 0.043144967406988144, 0.01829061657190323, 0.008692046627402306, 0.011046255007386208, 0.005306249018758535, 0.007556980475783348, 0.02095170132815838, 0.021388478577136993, 0.010002369061112404, 0.03070264868438244, 0.0374312698841095, 0.009889597073197365, 0.032535843551158905, 0.008054913952946663, 0.024852629750967026, 0.09951009601354599, 0.05275336652994156, 0.041850317269563675], [0.029845967888832092, 0.009356853552162647, 0.011831148527562618, 0.017901089042425156, 0.018153132870793343, 0.008945891633629799, 0.023922964930534363, 0.025492949411273003, 0.006635240279138088, 0.04066052287817001, 0.06464426219463348, 0.009255664423108101, 0.07406419515609741, 0.19371077418327332, 0.004616754595190287, 0.005177694838494062, 0.020497579127550125, 0.0027737615164369345, 0.0063100638799369335, 0.004263404291123152, 0.026006609201431274, 0.006415397860109806, 0.006229278165847063, 0.00301797641441226, 0.006784028373658657, 0.010587072931230068, 0.004864447750151157, 0.006039727013558149, 0.001957525033503771, 0.011962147429585457, 0.0025379862636327744, 0.00606742175295949, 0.004591267090290785, 0.017935214564204216, 0.0068971230648458, 0.004653469659388065, 0.00620429078117013, 0.0027531504165381193, 0.0041602239944040775, 0.013698910363018513, 0.0068175517953932285, 0.005964879412204027, 0.0076668839901685715, 0.02024681307375431, 0.005466714967042208, 0.010654945857822895, 0.004744573496282101, 0.00738628301769495, 0.08367031067609787, 0.033194467425346375, 0.0055319503881037235, 0.07723145931959152], [0.014805791899561882, 0.005431131459772587, 0.009314880706369877, 0.01318663265556097, 0.01605967804789543, 0.006286265794187784, 0.025392545387148857, 0.018600601702928543, 0.005151634104549885, 0.025477418676018715, 0.05498684570193291, 0.006903030443936586, 0.05389771983027458, 0.2963863015174866, 0.004005300812423229, 0.003327252110466361, 0.008731693960726261, 0.0025601405650377274, 0.006495229434221983, 0.004389557056128979, 0.014246001839637756, 0.00503295985981822, 0.005506354849785566, 0.0032687450293451548, 0.007569681853055954, 0.010592901147902012, 0.004452903755009174, 0.007211495190858841, 0.001844224170781672, 0.011108104139566422, 0.0030599008314311504, 0.007294662296772003, 0.005294982343912125, 0.027103455737233162, 0.008321686647832394, 0.0055191232822835445, 0.00740584684535861, 0.00226288172416389, 0.003572826273739338, 0.011371280066668987, 0.007220237981528044, 0.005492098163813353, 0.008589747361838818, 0.019333845004439354, 0.005982281640172005, 0.011677997186779976, 0.003320471616461873, 0.005713593680411577, 0.04442286118865013, 0.023654546588659286, 0.007437773048877716, 0.05416572093963623, 0.06955922394990921], [0.030886560678482056, 0.0069791171699762344, 0.010621068999171257, 0.012948300689458847, 0.014100627042353153, 0.00769401527941227, 0.021502038463950157, 0.02052539959549904, 0.004282786510884762, 0.02285405434668064, 0.04192390665411949, 0.006638410501182079, 0.033111121505498886, 0.10335128009319305, 0.0120385205373168, 0.013448713347315788, 0.01225946843624115, 0.0021273992024362087, 0.005671870429068804, 0.004247742705047131, 0.012734374031424522, 0.0034433752298355103, 0.004684022627770901, 0.0026385087985545397, 0.0069176144897937775, 0.010009931400418282, 0.004753479268401861, 0.005579655524343252, 0.001836660085245967, 0.01411060057580471, 0.0028210857417434454, 0.007763805333524942, 0.0067834327928721905, 0.017043817788362503, 0.00741729699075222, 0.003945589996874332, 0.004987186752259731, 0.002029894618317485, 0.003356597851961851, 0.01059208158403635, 0.007196095772087574, 0.006216209381818771, 0.007541321218013763, 0.017565777525305748, 0.004815485794097185, 0.01597539335489273, 0.004997907672077417, 0.007993407547473907, 0.07559744268655777, 0.035558462142944336, 0.0047532422468066216, 0.06716419756412506, 0.043441664427518845, 0.1805219054222107], [0.03678257763385773, 0.008460587821900845, 0.012341314926743507, 0.017171287909150124, 0.018935400992631912, 0.00777228781953454, 0.031141022220253944, 0.02418048307299614, 0.006672105751931667, 0.023711957037448883, 0.04684443771839142, 0.006352630909532309, 0.03492925688624382, 0.09754712134599686, 0.00863850861787796, 0.013105696998536587, 0.051307424902915955, 0.004857450257986784, 0.009917285293340683, 0.008166548795998096, 0.0306437686085701, 0.006252396386116743, 0.00885247066617012, 0.0029372177086770535, 0.009506803005933762, 0.013382675126194954, 0.006116298958659172, 0.008002613671123981, 0.0031533902511000633, 0.02127489075064659, 0.003469158662483096, 0.010877970606088638, 0.006873830687254667, 0.02029469795525074, 0.010801443830132484, 0.005380368325859308, 0.006281590089201927, 0.0035631461068987846, 0.005411828402429819, 0.014275015331804752, 0.010393493808805943, 0.007020364049822092, 0.009569293819367886, 0.020363373681902885, 0.005839608609676361, 0.01858023926615715, 0.009311226196587086, 0.007450100965797901, 0.047129079699516296, 0.0215318500995636, 0.005302398465573788, 0.04272808879613876, 0.039412982761859894, 0.06792821735143661, 0.021252693608403206], [0.020883696153759956, 0.011231882497668266, 0.011988221667706966, 0.014069569297134876, 0.01919497549533844, 0.006798054091632366, 0.02941402606666088, 0.022818943485617638, 0.012575415894389153, 0.03311750292778015, 0.06685224920511246, 0.00566851207986474, 0.044391926378011703, 0.17788606882095337, 0.006548765115439892, 0.006877278909087181, 0.03682956472039223, 0.004983730148524046, 0.01057633850723505, 0.01123303547501564, 0.01775171607732773, 0.005331262014806271, 0.005699256435036659, 0.003046506317332387, 0.009038293734192848, 0.012877743691205978, 0.005152946803718805, 0.007081237155944109, 0.0022219547536224127, 0.012519066222012043, 0.004914190620183945, 0.010167332366108894, 0.004644419532269239, 0.018556110560894012, 0.0092964181676507, 0.004754948429763317, 0.004787215497344732, 0.002499803202226758, 0.0046852221712470055, 0.010919508524239063, 0.007328919135034084, 0.005055148154497147, 0.010349984280765057, 0.015537272207438946, 0.0038022773806005716, 0.013576743192970753, 0.003973009530454874, 0.0064732967875897884, 0.03816528245806694, 0.014428729191422462, 0.0064849285408854485, 0.03393794596195221, 0.02937316708266735, 0.06204122677445412, 0.018887773156166077, 0.02069932594895363], [0.01547426637262106, 0.00634113559499383, 0.011428107507526875, 0.018634630367159843, 0.029027409851551056, 0.005275502800941467, 0.023331576958298683, 0.015509066171944141, 0.004711255896836519, 0.014731685630977154, 0.02882581576704979, 0.005399148445576429, 0.025954745709896088, 0.066549152135849, 0.005565768573433161, 0.005918659269809723, 0.01385867316275835, 0.004747435450553894, 0.0070851570926606655, 0.0060874950140714645, 0.015157492831349373, 0.005345547571778297, 0.007506800349801779, 0.003145994385704398, 0.007676109671592712, 0.01053087878972292, 0.007609982043504715, 0.008814141154289246, 0.004865539725869894, 0.045600809156894684, 0.009695664048194885, 0.02469647489488125, 0.004269601311534643, 0.020519638434052467, 0.006183835677802563, 0.0029936903156340122, 0.0032773574348539114, 0.0018836832605302334, 0.0029743111226707697, 0.007110999897122383, 0.004814234096556902, 0.003390687983483076, 0.005880820564925671, 0.01082239393144846, 0.0034115707967430353, 0.010294527746737003, 0.004966136999428272, 0.0066019585356116295, 0.019016381353139877, 0.008700346574187279, 0.003057644935324788, 0.02126944623887539, 0.026049772277474403, 0.06833743304014206, 0.009629352949559689, 0.008535618893802166, 0.2709065079689026], [0.013592551462352276, 0.00599918095394969, 0.01006416603922844, 0.012329496443271637, 0.02813711203634739, 0.0048746890388429165, 0.024429572746157646, 0.017215022817254066, 0.004544838797301054, 0.014228603802621365, 0.024712752550840378, 0.004066605120897293, 0.012155553326010704, 0.04097880423069, 0.003812947077676654, 0.0038307514041662216, 0.010077943094074726, 0.0029964169953018427, 0.008472763933241367, 0.005747221410274506, 0.009787751361727715, 0.006946276873350143, 0.006507911719381809, 0.003158428706228733, 0.009606707841157913, 0.01484742108732462, 0.003785130102187395, 0.007612478453665972, 0.0023041630629450083, 0.015318360179662704, 0.004938979633152485, 0.015615267679095268, 0.006332491058856249, 0.03514596074819565, 0.010721327736973763, 0.0047446549870073795, 0.005995329935103655, 0.0031610371079295874, 0.004953596740961075, 0.012422970496118069, 0.008261515758931637, 0.006195018067955971, 0.012316468171775341, 0.015119776129722595, 0.003459387691691518, 0.008322403766214848, 0.0033370282035320997, 0.004318542778491974, 0.016400102525949478, 0.008095119148492813, 0.0078207952901721, 0.014220540411770344, 0.011174238286912441, 0.038669437170028687, 0.006987564265727997, 0.005054570734500885, 0.05493425950407982, 0.33914005756378174], [0.008506502956151962, 0.0035799802280962467, 0.006399978883564472, 0.008075806312263012, 0.008857548236846924, 0.003758150152862072, 0.012013768777251244, 0.01782805472612381, 0.0027874098159372807, 0.007631024345755577, 0.013193740509450436, 0.003612624015659094, 0.008501802571117878, 0.026905229315161705, 0.0032098121009767056, 0.0030598416924476624, 0.0058018905110657215, 0.0023701279424130917, 0.004668392241001129, 0.003910496365278959, 0.007240586914122105, 0.00505600543692708, 0.005608804523944855, 0.002970050321891904, 0.0077426983043551445, 0.01017241831868887, 0.007786024361848831, 0.006552138365805149, 0.0022231002803891897, 0.012413798831403255, 0.005072384607046843, 0.009500635787844658, 0.005244510713964701, 0.027141306549310684, 0.017635026946663857, 0.010588192380964756, 0.01092529110610485, 0.0029496452771127224, 0.004896586760878563, 0.013197514228522778, 0.007092619314789772, 0.008849356323480606, 0.009337110444903374, 0.020220644772052765, 0.004987758584320545, 0.012312603183090687, 0.004545490723103285, 0.01381577830761671, 0.1169208511710167, 0.07195977121591568, 0.00519899558275938, 0.10851336270570755, 0.010284782387316227, 0.030598672106862068, 0.005682629533112049, 0.004927285015583038, 0.03300836309790611, 0.13651657104492188, 0.06563841551542282], [0.016587043181061745, 0.007398807909339666, 0.013290895149111748, 0.016470951959490776, 0.023100052028894424, 0.0063084871508181095, 0.02481692284345627, 0.019079288467764854, 0.005214032717049122, 0.013002715073525906, 0.022059248760342598, 0.004872986581176519, 0.010930899530649185, 0.0391177162528038, 0.00480531994253397, 0.005859974306076765, 0.008871643804013729, 0.004727629013359547, 0.008161906152963638, 0.005965116899460554, 0.008855951018631458, 0.008594823069870472, 0.009068753570318222, 0.006331776734441519, 0.015348583459854126, 0.03960682451725006, 0.017449310049414635, 0.00878522451967001, 0.003098608460277319, 0.0157772246748209, 0.005100222770124674, 0.012622563168406487, 0.0063313753344118595, 0.030217325314879417, 0.013076139613986015, 0.006752963177859783, 0.008179759606719017, 0.004201702773571014, 0.006614595651626587, 0.018087206408381462, 0.010369800962507725, 0.008499695919454098, 0.015746651217341423, 0.02766180969774723, 0.011534102261066437, 0.016470741480588913, 0.005347998347133398, 0.010266348719596863, 0.03776094689965248, 0.02253921888768673, 0.0065194652415812016, 0.03657319024205208, 0.007733463309705257, 0.03088395670056343, 0.0042597330175340176, 0.004797681234776974, 0.05085315555334091, 0.08110080659389496, 0.03178226575255394, 0.07455640286207199], [0.021253405138850212, 0.007423452101647854, 0.012343655340373516, 0.01458623819053173, 0.03346366435289383, 0.006598835811018944, 0.03346320614218712, 0.022195395082235336, 0.005627488251775503, 0.015622330829501152, 0.02695966325700283, 0.007420658599585295, 0.012543529272079468, 0.04259425029158592, 0.004346439149230719, 0.004440830554813147, 0.010128088295459747, 0.0030758751090615988, 0.009829380549490452, 0.006744575221091509, 0.010834154672920704, 0.008442206308245659, 0.009559564292430878, 0.007541922852396965, 0.012446260079741478, 0.01787923090159893, 0.005677969194948673, 0.011616440489888191, 0.003293650457635522, 0.01936577446758747, 0.007329417858272791, 0.02818182483315468, 0.007822960615158081, 0.06313885003328323, 0.013711820356547832, 0.0077721131965518, 0.009499235078692436, 0.006077896803617477, 0.007759453263133764, 0.021490534767508507, 0.016353748738765717, 0.013778081163764, 0.030424930155277252, 0.0368390753865242, 0.009471669793128967, 0.019674023613333702, 0.005718025378882885, 0.013162900693714619, 0.040188778191804886, 0.01801380142569542, 0.006536012515425682, 0.03639065474271774, 0.006331616546958685, 0.02361389622092247, 0.0027799189556390047, 0.004186367616057396, 0.03118188865482807, 0.05050234496593475, 0.010657506063580513, 0.010378006845712662, 0.033714547753334045], [0.022612985223531723, 0.008581487461924553, 0.014957294799387455, 0.01877705194056034, 0.029775090515613556, 0.007040796801447868, 0.03942827135324478, 0.023050649091601372, 0.005438539199531078, 0.018016640096902847, 0.033204298466444016, 0.006733025889843702, 0.01588066853582859, 0.06694970279932022, 0.004581390414386988, 0.003880048170685768, 0.012556459754705429, 0.007403104100376368, 0.009995318949222565, 0.007175436709076166, 0.013234613463282585, 0.008807661011815071, 0.00784585252404213, 0.006126695778220892, 0.012549757026135921, 0.01900072954595089, 0.00601549819111824, 0.011146504431962967, 0.0038889977149665356, 0.01983528397977352, 0.0068621025420725346, 0.021854398772120476, 0.009126713499426842, 0.060260795056819916, 0.013785392045974731, 0.006978463847190142, 0.008646710775792599, 0.005344517529010773, 0.007033228408545256, 0.019927382469177246, 0.012967050075531006, 0.00999829825013876, 0.02448352426290512, 0.028524914756417274, 0.009736192412674427, 0.013909964822232723, 0.004363800399005413, 0.009047942236065865, 0.024072695523500443, 0.013115198351442814, 0.004176322370767593, 0.027989206835627556, 0.0069837793707847595, 0.026109714061021805, 0.0021705711260437965, 0.004769116640090942, 0.027468770742416382, 0.044022317975759506, 0.010589424520730972, 0.011225324124097824, 0.015706820413470268, 0.04425950348377228], [0.01895136572420597, 0.008268921636044979, 0.016607927158474922, 0.01695920340716839, 0.030994947999715805, 0.0068772416561841965, 0.03335089981555939, 0.021679051220417023, 0.005499332677572966, 0.014444910921156406, 0.021799083799123764, 0.0062435343861579895, 0.011513642966747284, 0.051342882215976715, 0.003836582414805889, 0.003928754013031721, 0.00980050303041935, 0.006267700344324112, 0.009246188215911388, 0.006059302948415279, 0.010903836227953434, 0.006927368231117725, 0.008913237601518631, 0.005981985479593277, 0.012558972463011742, 0.01921357959508896, 0.005835913587361574, 0.011833800934255123, 0.011429227888584137, 0.03478739783167839, 0.00716960895806551, 0.018286366015672684, 0.01196175254881382, 0.06014878302812576, 0.012134759686887264, 0.005975992884486914, 0.007912267930805683, 0.004073326475918293, 0.006199325434863567, 0.0182226300239563, 0.012589985504746437, 0.007051466498523951, 0.018396837636828423, 0.027872635051608086, 0.00648586917668581, 0.013424810022115707, 0.003960318863391876, 0.00859866850078106, 0.025369534268975258, 0.016843702644109726, 0.004851765930652618, 0.026780210435390472, 0.009593366645276546, 0.03742297366261482, 0.0022638000082224607, 0.0048475367948412895, 0.03279094770550728, 0.06348242610692978, 0.010257062502205372, 0.010602387599647045, 0.01764221303164959, 0.029719898477196693, 0.025009432807564735], [0.012835480272769928, 0.005583026446402073, 0.013907556422054768, 0.015350256115198135, 0.01790931634604931, 0.005332148168236017, 0.021461989730596542, 0.017678460106253624, 0.004271109122782946, 0.01296936348080635, 0.021129652857780457, 0.004524333402514458, 0.015036053955554962, 0.041854873299598694, 0.00590661121532321, 0.003608827944844961, 0.012750713154673576, 0.004282175563275814, 0.008130340836942196, 0.006444293074309826, 0.039992962032556534, 0.006980393081903458, 0.00636336300522089, 0.004712251480668783, 0.012648380361497402, 0.015735307708382607, 0.005592619068920612, 0.007580758072435856, 0.004408620297908783, 0.015638427808880806, 0.004490064922720194, 0.012032190337777138, 0.00557285500690341, 0.0373808816075325, 0.013699165545403957, 0.006307731848210096, 0.00629659928381443, 0.0036869077011942863, 0.005640121642500162, 0.019035011529922485, 0.009094050154089928, 0.009082090109586716, 0.012127266265451908, 0.025783738121390343, 0.004990020766854286, 0.011262068524956703, 0.003446988295763731, 0.00860507320612669, 0.03755722567439079, 0.02046102285385132, 0.004557227250188589, 0.04220261052250862, 0.013289214111864567, 0.038276225328445435, 0.003826298052445054, 0.004990527871996164, 0.04238737374544144, 0.054965727031230927, 0.010717217810451984, 0.012119658291339874, 0.016531044617295265, 0.018060561269521713, 0.03377899155020714, 0.07712657749652863], [0.017296848818659782, 0.006146437954157591, 0.013050178065896034, 0.013666006736457348, 0.01653299666941166, 0.005284830927848816, 0.02342263050377369, 0.01569521799683571, 0.0036601140163838863, 0.009921815246343613, 0.017543651163578033, 0.004341830965131521, 0.011513384990394115, 0.029814239591360092, 0.0031907735392451286, 0.0029637031257152557, 0.008026789873838425, 0.0039010876789689064, 0.007115367334336042, 0.004610814619809389, 0.016098544001579285, 0.00635188352316618, 0.00561049859970808, 0.003349071368575096, 0.010101384483277798, 0.013606395572423935, 0.003980440087616444, 0.00876337569206953, 0.003099568886682391, 0.01199655793607235, 0.0036569819785654545, 0.01431623287498951, 0.005066505633294582, 0.027882415801286697, 0.012326476164162159, 0.005391959100961685, 0.0067866044119000435, 0.004214475862681866, 0.005955667234957218, 0.01777583546936512, 0.008092552423477173, 0.007947446778416634, 0.015460951253771782, 0.019414352253079414, 0.0034646850544959307, 0.007036643568426371, 0.0035674634855240583, 0.007841408252716064, 0.027342282235622406, 0.007301177363842726, 0.0031842589378356934, 0.016589853912591934, 0.010860814712941647, 0.03758639469742775, 0.002218665089458227, 0.004179026931524277, 0.02843567728996277, 0.04153607785701752, 0.009791309013962746, 0.01062584389001131, 0.012112746015191078, 0.02093954011797905, 0.01679139956831932, 0.04042533040046692, 0.23322442173957825], [0.018598774448037148, 0.00652120728045702, 0.018955271691083908, 0.016893571242690086, 0.023642655462026596, 0.005268499255180359, 0.028537709265947342, 0.02034199796617031, 0.0044367569498717785, 0.01292630098760128, 0.02030961774289608, 0.0044418624602258205, 0.01197903323918581, 0.03267759457230568, 0.003745513968169689, 0.0030524933245033026, 0.009381940588355064, 0.0032371252309530973, 0.008736916817724705, 0.005845848936587572, 0.015912016853690147, 0.007337288465350866, 0.005672539584338665, 0.00476522883400321, 0.013553621247410774, 0.01632368192076683, 0.004479729570448399, 0.00849753525108099, 0.0028185658156871796, 0.01534856203943491, 0.003922628704458475, 0.015171578153967857, 0.004795267712324858, 0.034897346049547195, 0.011979004368185997, 0.0057693906128406525, 0.006372653879225254, 0.003522770944982767, 0.006297154352068901, 0.0155215784907341, 0.012010014615952969, 0.005689288955181837, 0.01532459445297718, 0.024973275139927864, 0.0030691141728311777, 0.007102825678884983, 0.002303273184224963, 0.006757811177521944, 0.024235015735030174, 0.007618576288223267, 0.006766908336430788, 0.01076811645179987, 0.00854476634413004, 0.027801165357232094, 0.0018274355679750443, 0.0036496936809271574, 0.022595083341002464, 0.043631669133901596, 0.007710618432611227, 0.009954371489584446, 0.01435413584113121, 0.014014523476362228, 0.011464281938970089, 0.017323557287454605, 0.13642720878124237, 0.09159382432699203], [0.03434240072965622, 0.007546942215412855, 0.01262525375932455, 0.016252918168902397, 0.01943065971136093, 0.00990856159478426, 0.027735935524106026, 0.017991697415709496, 0.005064910743385553, 0.011717415414750576, 0.02222997508943081, 0.006603062152862549, 0.011647496372461319, 0.04147420823574066, 0.00420520082116127, 0.0033061043359339237, 0.00840428564697504, 0.004123447462916374, 0.006662738509476185, 0.004977744072675705, 0.008326105773448944, 0.0062074135057628155, 0.007645832374691963, 0.004328862763941288, 0.011004374362528324, 0.02069890685379505, 0.008648925460875034, 0.0083983289077878, 0.003134029218927026, 0.013410710729658604, 0.004132104106247425, 0.014399122446775436, 0.006474950350821018, 0.03789469972252846, 0.01231063436716795, 0.007019704207777977, 0.01264934428036213, 0.008924518711864948, 0.00475325295701623, 0.014265312813222408, 0.00908783357590437, 0.00514258211478591, 0.012306513264775276, 0.018606949597597122, 0.004004263784736395, 0.00845225527882576, 0.0030571171082556248, 0.005867111962288618, 0.022412797436118126, 0.008147994056344032, 0.0028391515370458364, 0.016519559547305107, 0.008755836635828018, 0.02606263756752014, 0.002428078791126609, 0.004019671119749546, 0.02392592467367649, 0.037634026259183884, 0.009634766727685928, 0.010280200280249119, 0.013219551183283329, 0.022362494841217995, 0.011527587659657001, 0.026092855259776115, 0.07722707837820053, 0.0471862368285656, 0.0723208412528038], [0.022260548546910286, 0.007827301509678364, 0.016054008156061172, 0.02251431718468666, 0.024919068440794945, 0.008432946167886257, 0.041243281215429306, 0.01821194216609001, 0.004570990335196257, 0.021145178005099297, 0.035994429141283035, 0.006092384457588196, 0.021389396861195564, 0.08146101236343384, 0.003937745466828346, 0.00369447935372591, 0.02155596762895584, 0.003996813204139471, 0.006303656846284866, 0.004242696333676577, 0.015697326511144638, 0.0061682527884840965, 0.005011096131056547, 0.003403191454708576, 0.007988644763827324, 0.011214821599423885, 0.003161713480949402, 0.006709401495754719, 0.0026424797251820564, 0.010808693245053291, 0.0036973687820136547, 0.010656625963747501, 0.00441548740491271, 0.02873259410262108, 0.008273668587207794, 0.003804202424362302, 0.005169945769011974, 0.005301240831613541, 0.004103054292500019, 0.010758196003735065, 0.007981873117387295, 0.0042779636569321156, 0.009148800745606422, 0.015596581622958183, 0.0035910983569920063, 0.0062990509904921055, 0.0024203818757086992, 0.004885077942162752, 0.0215991772711277, 0.008731036446988583, 0.003824693849310279, 0.0206054225564003, 0.009703862480819225, 0.03652593120932579, 0.0024792728945612907, 0.003675516229122877, 0.038111936300992966, 0.035174425691366196, 0.006942955777049065, 0.008295618928968906, 0.012356607243418694, 0.018206050619482994, 0.013794799335300922, 0.03829961270093918, 0.059833817183971405, 0.023556193336844444, 0.03129233792424202, 0.01922375150024891], [0.012460466474294662, 0.005923563614487648, 0.0099134910851717, 0.013811648823320866, 0.016999375075101852, 0.006226206198334694, 0.04780562222003937, 0.026749510318040848, 0.0038752481341362, 0.013204637914896011, 0.027692170813679695, 0.005729828495532274, 0.011784560978412628, 0.04404868185520172, 0.003427949734032154, 0.0030529904179275036, 0.008908616378903389, 0.002915774006396532, 0.006894622929394245, 0.004174915142357349, 0.00873450469225645, 0.005487669259309769, 0.005306388717144728, 0.0030241229105740786, 0.007527521811425686, 0.010668760165572166, 0.003629630897194147, 0.007069790735840797, 0.0028563914820551872, 0.011868217028677464, 0.003643444273620844, 0.00951563473790884, 0.0042749326676130295, 0.02192341908812523, 0.008545957505702972, 0.004106726963073015, 0.005097523797303438, 0.004084778483957052, 0.005737014580518007, 0.013218753971159458, 0.007764376234263182, 0.005457489285618067, 0.011922544799745083, 0.018171876668930054, 0.0038008992560207844, 0.008195038884878159, 0.0028012164402753115, 0.0043671405874192715, 0.023646196350455284, 0.010953476652503014, 0.003031786996871233, 0.02137269824743271, 0.0107041010633111, 0.04502250626683235, 0.00239697122015059, 0.005145795177668333, 0.030968843027949333, 0.04488557577133179, 0.007957383058965206, 0.008325427770614624, 0.010251530446112156, 0.016853220760822296, 0.018661225214600563, 0.033806391060352325, 0.0469420924782753, 0.018598409369587898, 0.032954033464193344, 0.010291291400790215, 0.11282940208911896], [0.01570301689207554, 0.004536045249551535, 0.008458666503429413, 0.010786565952003002, 0.01423121802508831, 0.004571377765387297, 0.0314352884888649, 0.019694145768880844, 0.0035300489980727434, 0.010167817585170269, 0.016662653535604477, 0.004707202780991793, 0.008690256625413895, 0.0287831611931324, 0.0033740417566150427, 0.0029134114738553762, 0.00777049595490098, 0.003336431225761771, 0.008638715371489525, 0.004779792856425047, 0.008038888685405254, 0.009764275513589382, 0.006251155398786068, 0.0038781713228672743, 0.008634593337774277, 0.012385590001940727, 0.003818944562226534, 0.00696566142141819, 0.0029796049930155277, 0.010537314228713512, 0.0038395279552787542, 0.011967258527874947, 0.0055381134152412415, 0.02151205949485302, 0.011540571227669716, 0.006344438996165991, 0.005954327527433634, 0.0040033902041614056, 0.005273581016808748, 0.015147756785154343, 0.00993005558848381, 0.008649664930999279, 0.014407931827008724, 0.02406340278685093, 0.006063639186322689, 0.01803925260901451, 0.006142819300293922, 0.012106540612876415, 0.022470751777291298, 0.010915970429778099, 0.0037789135240018368, 0.026470400393009186, 0.010615076869726181, 0.035489778965711594, 0.0023900731466710567, 0.004049124661833048, 0.02521912381052971, 0.045000068843364716, 0.012854422442615032, 0.012222576886415482, 0.012691572308540344, 0.020723454654216766, 0.011135205626487732, 0.020811714231967926, 0.04152083769440651, 0.018165668472647667, 0.018503013998270035, 0.006500758696347475, 0.047411151230335236, 0.11451146006584167]]},\n",
               "                preset: 'viridis'\n",
               "             })\n",
               "\n",
@@ -2430,15 +4703,15 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 119
+          "height": 153
         },
         "id": "3IJf31V-woi_",
-        "outputId": "351aa4af-7111-451f-bc26-02d2026bbe59"
+        "outputId": "d3295230-13e2-4dfb-de91-1eaf166b2d6a"
       },
       "source": [
         "output.saliency(style=\"detailed\")"
       ],
-      "execution_count": 142,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2533,7 +4806,7 @@
               "\n",
               "             requirejs(['basic', 'ecco'], function(basic, ecco){\n",
               "                const viz_id = basic.init()\n",
-              "                window.ecco[viz_id] = ecco.interactiveTokens(viz_id, {'tokens': [{'token': 'در', 'token_id': 589, 'type': 'input', 'value': '0.120529495', 'position': 0}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'value': '0.05264326', 'position': 1}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'input', 'value': '0.11394182', 'position': 2}, {'token': ' شگفت', 'token_id': 3844, 'type': 'input', 'value': '0.16398367', 'position': 3}, {'token': ' انگیز', 'token_id': 5904, 'type': 'input', 'value': '0.14254722', 'position': 4}, {'token': '،', 'token_id': 305, 'type': 'input', 'value': '0.058095437', 'position': 5}, {'token': ' پژوهشگران', 'token_id': 4579, 'type': 'input', 'value': '0.34825912', 'position': 6}, {'token': ' برای', 'token_id': 366, 'type': 'output', 'value': '0', 'position': 7}, {'token': ' نخستین', 'token_id': 1817, 'type': 'output', 'value': '0', 'position': 8}, {'token': ' بار', 'token_id': 761, 'type': 'output', 'value': '0', 'position': 9}, {'token': ' متوجه', 'token_id': 2298, 'type': 'output', 'value': '0', 'position': 10}, {'token': ' شدند', 'token_id': 1436, 'type': 'output', 'value': '0', 'position': 11}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 12}, {'token': ' \\u200c', 'token_id': 1570, 'type': 'output', 'value': '0', 'position': 13}, {'token': ' پروتئین', 'token_id': 4398, 'type': 'output', 'value': '0', 'position': 14}, {'token': 'های', 'token_id': 325, 'type': 'output', 'value': '0', 'position': 15}, {'token': ' موجود', 'token_id': 1294, 'type': 'output', 'value': '0', 'position': 16}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 17}, {'token': ' سلول', 'token_id': 2829, 'type': 'output', 'value': '0', 'position': 18}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 19}, {'token': 'های', 'token_id': 325, 'type': 'output', 'value': '0', 'position': 20}, {'token': ' پستانداران', 'token_id': 13287, 'type': 'output', 'value': '0', 'position': 21}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 22}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 23}, {'token': ' وظیفه', 'token_id': 3188, 'type': 'output', 'value': '0', 'position': 24}, {'token': ' تولیدمثل', 'token_id': 29777, 'type': 'output', 'value': '0', 'position': 25}, {'token': ' را', 'token_id': 330, 'type': 'output', 'value': '0', 'position': 26}, {'token': ' بر', 'token_id': 327, 'type': 'output', 'value': '0', 'position': 27}, {'token': ' عهده', 'token_id': 2693, 'type': 'output', 'value': '0', 'position': 28}, {'token': ' دارند', 'token_id': 712, 'type': 'output', 'value': '0', 'position': 29}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 30}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 31}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 32}, {'token': 'توانند', 'token_id': 1006, 'type': 'output', 'value': '0', 'position': 33}, {'token': ' با', 'token_id': 314, 'type': 'output', 'value': '0', 'position': 34}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 35}, {'token': ' شرایط', 'token_id': 1138, 'type': 'output', 'value': '0', 'position': 36}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 37}, {'token': ' خصوص', 'token_id': 1279, 'type': 'output', 'value': '0', 'position': 38}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 39}, {'token': ' حالت', 'token_id': 1471, 'type': 'output', 'value': '0', 'position': 40}, {'token': ' استراحت', 'token_id': 5045, 'type': 'output', 'value': '0', 'position': 41}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 42}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 43}, {'token': ' مسیر', 'token_id': 1418, 'type': 'output', 'value': '0', 'position': 44}, {'token': ' بدهند', 'token_id': 5332, 'type': 'output', 'value': '0', 'position': 45}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 46}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 47}, {'token': ' گفته', 'token_id': 1023, 'type': 'output', 'value': '0', 'position': 48}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 49}, {'token': ' تیم', 'token_id': 935, 'type': 'output', 'value': '0', 'position': 50}, {'token': ' پژوهشی', 'token_id': 5296, 'type': 'output', 'value': '0', 'position': 51}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 52}, {'token': ' \\u200c', 'token_id': 1570, 'type': 'output', 'value': '0', 'position': 53}, {'token': ' پروتئینی', 'token_id': 14062, 'type': 'output', 'value': '0', 'position': 54}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 55}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 56}, {'token': ' طول', 'token_id': 1033, 'type': 'output', 'value': '0', 'position': 57}, {'token': ' چرخه', 'token_id': 5081, 'type': 'output', 'value': '0', 'position': 58}, {'token': ' حیات', 'token_id': 4237, 'type': 'output', 'value': '0', 'position': 59}, {'token': ' خود', 'token_id': 377, 'type': 'output', 'value': '0', 'position': 60}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 61}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 62}, {'token': 'تواند', 'token_id': 663, 'type': 'output', 'value': '0', 'position': 63}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 64}, {'token': ' میزان', 'token_id': 1252, 'type': 'output', 'value': '0', 'position': 65}, {'token': ' قابل', 'token_id': 1045, 'type': 'output', 'value': '0', 'position': 66}, {'token': ' توجهی', 'token_id': 3424, 'type': 'output', 'value': '0', 'position': 67}, {'token': ' تغییر', 'token_id': 828, 'type': 'output', 'value': '0', 'position': 68}, {'token': ' مسیر', 'token_id': 1418, 'type': 'output', 'value': '0', 'position': 69}, {'token': ' بدهد', 'token_id': 3866, 'type': 'output', 'value': '0', 'position': 70}], 'attributions': [[0.12052949517965317, 0.05264326184988022, 0.11394181847572327, 0.16398367285728455, 0.14254721999168396, 0.05809543654322624, 0.3482591211795807], [0.1781502664089203, 0.06820687651634216, 0.12039405107498169, 0.15711303055286407, 0.16788733005523682, 0.04340321943163872, 0.20059633255004883, 0.06424884498119354], [0.08585289865732193, 0.040032535791397095, 0.07826150953769684, 0.12479200959205627, 0.15820591151714325, 0.03708841651678085, 0.17505423724651337, 0.07700830698013306, 0.22370417416095734], [0.11525771021842957, 0.04457148164510727, 0.09094107896089554, 0.1231161430478096, 0.10062672942876816, 0.0298308115452528, 0.20600777864456177, 0.04154171049594879, 0.1282319277524948, 0.11987464874982834], [0.08803491294384003, 0.03329388424754143, 0.07146862149238586, 0.09924773871898651, 0.08452096581459045, 0.026380598545074463, 0.16145983338356018, 0.028535939753055573, 0.0587216354906559, 0.056490447372198105, 0.2918453812599182], [0.09408842772245407, 0.031251899898052216, 0.06169586628675461, 0.08931385725736618, 0.08660504966974258, 0.04297078400850296, 0.15246358513832092, 0.024139394983649254, 0.0757228434085846, 0.03318798914551735, 0.15693354606628418, 0.15162670612335205], [0.11074426770210266, 0.0359828881919384, 0.059685591608285904, 0.09184788912534714, 0.11247868090867996, 0.042484674602746964, 0.14790046215057373, 0.026875022798776627, 0.07459121197462082, 0.03547780588269234, 0.10972238332033157, 0.10522313416004181, 0.046985968947410583], [0.10008340328931808, 0.025656452402472496, 0.04576603323221207, 0.06769827008247375, 0.08492779731750488, 0.028991401195526123, 0.142159104347229, 0.018878484144806862, 0.049313466995954514, 0.027413062751293182, 0.11616713553667068, 0.08785500377416611, 0.04787037894129753, 0.1572200208902359], [0.06682416796684265, 0.02473749779164791, 0.043947797268629074, 0.09157176315784454, 0.11014430969953537, 0.020965108647942543, 0.07059634476900101, 0.012052700854837894, 0.030799003317952156, 0.018830234184861183, 0.04963789880275726, 0.04896589741110802, 0.02399306371808052, 0.036727096885442734, 0.3502071797847748], [0.0683305412530899, 0.017187124118208885, 0.03306121379137039, 0.05194312334060669, 0.06057991087436676, 0.020688673481345177, 0.09220581501722336, 0.015998588874936104, 0.03643724322319031, 0.02707723341882229, 0.051272109150886536, 0.05546336993575096, 0.020004864782094955, 0.03433840721845627, 0.30479511618614197, 0.11061664670705795], [0.061967913061380386, 0.018488025292754173, 0.03545275703072548, 0.05181359127163887, 0.052410148084163666, 0.017373457551002502, 0.08617506176233292, 0.01590169407427311, 0.04398893937468529, 0.02074064500629902, 0.06341993808746338, 0.055386681109666824, 0.015995897352695465, 0.032249629497528076, 0.2015593945980072, 0.05463571846485138, 0.17244043946266174], [0.10801324993371964, 0.01787499710917473, 0.031199021264910698, 0.04383867233991623, 0.04472817853093147, 0.016828149557113647, 0.08445969223976135, 0.012985942885279655, 0.03808780014514923, 0.0188908651471138, 0.05729240924119949, 0.04407313093543053, 0.016005342826247215, 0.033385567367076874, 0.2115548700094223, 0.04349305480718613, 0.1288757026195526, 0.048413392156362534], [0.05091400817036629, 0.01616712659597397, 0.03452746570110321, 0.05129971355199814, 0.05098560452461243, 0.015248192474246025, 0.08821036666631699, 0.014368843287229538, 0.038764189928770065, 0.01923242211341858, 0.056495919823646545, 0.04840634763240814, 0.012078269384801388, 0.025353820994496346, 0.16269926726818085, 0.031153390184044838, 0.03889095410704613, 0.01758343167603016, 0.22762072086334229], [0.05794253200292587, 0.01628996804356575, 0.030956001952290535, 0.048469219356775284, 0.07193323224782944, 0.015065977349877357, 0.08058343827724457, 0.012861005030572414, 0.04086778312921524, 0.019433220848441124, 0.052695419639348984, 0.04321274906396866, 0.02103840932250023, 0.06902316212654114, 0.10923442244529724, 0.03399530053138733, 0.03870614618062973, 0.019765682518482208, 0.17655426263809204, 0.04137201979756355], [0.059533897787332535, 0.013473530299961567, 0.023743199184536934, 0.037638530135154724, 0.03918318822979927, 0.014258407056331635, 0.06322062760591507, 0.011859474703669548, 0.033062104135751724, 0.019262412562966347, 0.03792892023921013, 0.04081698879599571, 0.013224292546510696, 0.022846901789307594, 0.12221086025238037, 0.05412381887435913, 0.04564881697297096, 0.018574092537164688, 0.2247500717639923, 0.047885097563266754, 0.0567547045648098], [0.06679655611515045, 0.017190519720315933, 0.03108084946870804, 0.038217395544052124, 0.0470476932823658, 0.021205104887485504, 0.06444563716650009, 0.014056903310120106, 0.042796023190021515, 0.019443659111857414, 0.05829240754246712, 0.049793828278779984, 0.018263621255755424, 0.022073743864893913, 0.09156564623117447, 0.03186255320906639, 0.04384220018982887, 0.014916411601006985, 0.048949480056762695, 0.008266408927738667, 0.016767537221312523, 0.23312582075595856], [0.05355146899819374, 0.017224840819835663, 0.029187941923737526, 0.0426604263484478, 0.06504445523023605, 0.022366279736161232, 0.06805460900068283, 0.01308570895344019, 0.040810033679008484, 0.019774237647652626, 0.06783484667539597, 0.05948541313409805, 0.022732889279723167, 0.05196090415120125, 0.0975290983915329, 0.026779964566230774, 0.03947295621037483, 0.014418243430554867, 0.037933360785245895, 0.010504367761313915, 0.015254414640367031, 0.15130159258842468, 0.033031951636075974], [0.044610727578401566, 0.013888600282371044, 0.025301320478320122, 0.03200257942080498, 0.037291619926691055, 0.01604093238711357, 0.0637740045785904, 0.014160341583192348, 0.029468804597854614, 0.015509107150137424, 0.04298367351293564, 0.0451163649559021, 0.01663612760603428, 0.0275103896856308, 0.16187900304794312, 0.05149355158209801, 0.03175656124949455, 0.01569346711039543, 0.061871156096458435, 0.009652108885347843, 0.016290457919239998, 0.10452806949615479, 0.048391811549663544, 0.0741492211818695], [0.046329934149980545, 0.017003199085593224, 0.03769191727042198, 0.05262945964932442, 0.07012979686260223, 0.016141319647431374, 0.057715389877557755, 0.009191513061523438, 0.027432991191744804, 0.0148128317669034, 0.036791469901800156, 0.03133179619908333, 0.016394516453146935, 0.030294254422187805, 0.11061524599790573, 0.02585873380303383, 0.0196284931153059, 0.012044275179505348, 0.06659706681966782, 0.011490987613797188, 0.010524553246796131, 0.10530177503824234, 0.01715066470205784, 0.025770606473088264, 0.1311272382736206], [0.022170666605234146, 0.007515456527471542, 0.01275520771741867, 0.01685541681945324, 0.019768359139561653, 0.008365833200514317, 0.03009558841586113, 0.008181165903806686, 0.018263520672917366, 0.007912171073257923, 0.022027689963579178, 0.01678585074841976, 0.00669445563107729, 0.011880561709403992, 0.04938065633177757, 0.013058812357485294, 0.014088821597397327, 0.007192803546786308, 0.04481947422027588, 0.006382938474416733, 0.008895665407180786, 0.07350654155015945, 0.015245949849486351, 0.02427440881729126, 0.0821949690580368, 0.4516870081424713], [0.0316193513572216, 0.01664142496883869, 0.028066735714673996, 0.03340279310941696, 0.06253629922866821, 0.014956277795135975, 0.06107702478766441, 0.012527846731245518, 0.04718412086367607, 0.019503114745020866, 0.045003436505794525, 0.035772960633039474, 0.015543406829237938, 0.03352576494216919, 0.04764629155397415, 0.015532576479017735, 0.019454972818493843, 0.009663033299148083, 0.029114389792084694, 0.0090880012139678, 0.009287944063544273, 0.06675756722688675, 0.017313070595264435, 0.02498612552881241, 0.10500133037567139, 0.1434587687253952, 0.045335397124290466], [0.040057118982076645, 0.013866810128092766, 0.021658478304743767, 0.028256958350539207, 0.044955022633075714, 0.015425854362547398, 0.04593735188245773, 0.01164078339934349, 0.030622445046901703, 0.01509111374616623, 0.03310069814324379, 0.026648936793208122, 0.015577562153339386, 0.028945397585630417, 0.06087426468729973, 0.018932336941361427, 0.020127715542912483, 0.01554876659065485, 0.03285757079720497, 0.009324670769274235, 0.008118847385048866, 0.06494399160146713, 0.0197165384888649, 0.02130477875471115, 0.08254265785217285, 0.1657130867242813, 0.03759758919477463, 0.07061261683702469], [0.04350912943482399, 0.0117940129712224, 0.017678480595350266, 0.027166398242115974, 0.041386693716049194, 0.01175431627780199, 0.037511520087718964, 0.00933605246245861, 0.02735034190118313, 0.012312370352447033, 0.036652546375989914, 0.0314638614654541, 0.01259779091924429, 0.02912917733192444, 0.05133650824427605, 0.020252300426363945, 0.01707075536251068, 0.009374774061143398, 0.02938845194876194, 0.008849911391735077, 0.009274852462112904, 0.06530443578958511, 0.017726220190525055, 0.024164756760001183, 0.04433634132146835, 0.14272987842559814, 0.024084841832518578, 0.03326699882745743, 0.15319624543190002], [0.047412898391485214, 0.01729159615933895, 0.025585124269127846, 0.03476784750819206, 0.06053222715854645, 0.01685561053454876, 0.06244873255491257, 0.012086973525583744, 0.03956989198923111, 0.018232429400086403, 0.05182943493127823, 0.04090454429388046, 0.015310581773519516, 0.03709840402007103, 0.06720246374607086, 0.020530391484498978, 0.022866057232022285, 0.010241278447210789, 0.02432427741587162, 0.01119182351976633, 0.013898319564759731, 0.09146082401275635, 0.02494671568274498, 0.0307119432836771, 0.019031591713428497, 0.07317810505628586, 0.010543742217123508, 0.01156082097440958, 0.04753671959042549, 0.040848683565855026], [0.06375151872634888, 0.016584990546107292, 0.030575070530176163, 0.03978618234395981, 0.044322576373815536, 0.017769979313015938, 0.07163196802139282, 0.013906409032642841, 0.03576689958572388, 0.01830929145216942, 0.07260537892580032, 0.05580201745033264, 0.01504176203161478, 0.03426540270447731, 0.1139865517616272, 0.026516687124967575, 0.031124768778681755, 0.00707507086917758, 0.026405442506074905, 0.004637671634554863, 0.006909787654876709, 0.054560668766498566, 0.014549619518220425, 0.012206066399812698, 0.014515290036797523, 0.06165507435798645, 0.005324540194123983, 0.005999709479510784, 0.03003387711942196, 0.034408170729875565, 0.01997155323624611], [0.07903499901294708, 0.013610418885946274, 0.023362617939710617, 0.03789230436086655, 0.06319800019264221, 0.016094859689474106, 0.03947232663631439, 0.009349821135401726, 0.025776665657758713, 0.012295935302972794, 0.035385359078645706, 0.03596082702279091, 0.019014408811926842, 0.047334786504507065, 0.045795366168022156, 0.020682288333773613, 0.015671927481889725, 0.008824151009321213, 0.031672172248363495, 0.022250987589359283, 0.011274471879005432, 0.04708494991064072, 0.01935906708240509, 0.02244185097515583, 0.018920253962278366, 0.059457797557115555, 0.009633643552660942, 0.009478135965764523, 0.03261106461286545, 0.02773582562804222, 0.031094806268811226, 0.1082279309630394], [0.04200358688831329, 0.012756566517055035, 0.016206713393330574, 0.02200246788561344, 0.11984725296497345, 0.01084932405501604, 0.049216486513614655, 0.007543214596807957, 0.02825181372463703, 0.013501722365617752, 0.030333049595355988, 0.03457537665963173, 0.026713648810982704, 0.08499016612768173, 0.04379117116332054, 0.02162194810807705, 0.017063863575458527, 0.005317079368978739, 0.020406808704137802, 0.022163117304444313, 0.015634708106517792, 0.04561221972107887, 0.011388295330107212, 0.010500124655663967, 0.012649341486394405, 0.07127831876277924, 0.006798418704420328, 0.009531837888062, 0.03563649579882622, 0.028035156428813934, 0.014360911212861538, 0.04263094812631607, 0.06678789854049683], [0.04613664001226425, 0.00979230459779501, 0.019247552379965782, 0.02679455652832985, 0.03542318940162659, 0.011636771261692047, 0.04279673099517822, 0.00870715081691742, 0.023256609216332436, 0.011634673923254013, 0.03453413397073746, 0.035208698362112045, 0.01416589505970478, 0.029419301077723503, 0.08963396400213242, 0.03087901696562767, 0.01975388266146183, 0.006605716422200203, 0.031261686235666275, 0.006061528343707323, 0.007957120425999165, 0.06695055961608887, 0.013382485136389732, 0.01760844886302948, 0.018155984580516815, 0.15290983021259308, 0.007649615872651339, 0.006884512025862932, 0.03626174479722977, 0.024764683097600937, 0.01264912448823452, 0.01479305699467659, 0.007593050133436918, 0.0794897973537445], [0.03572550788521767, 0.010918752290308475, 0.018542645499110222, 0.028910059481859207, 0.027861973270773888, 0.013123911805450916, 0.045623764395713806, 0.00936872698366642, 0.03535052761435509, 0.014019068330526352, 0.033236064016819, 0.03324681520462036, 0.012048963457345963, 0.025090092793107033, 0.09889810532331467, 0.025393294170498848, 0.021118471398949623, 0.010778326541185379, 0.031588684767484665, 0.009296510368585587, 0.008715585805475712, 0.06658339500427246, 0.012191107496619225, 0.012523077428340912, 0.024097232148051262, 0.11542440205812454, 0.013435933738946915, 0.010620003566145897, 0.030910950154066086, 0.016796022653579712, 0.008246609941124916, 0.013970283791422844, 0.014519227668642998, 0.06942977011203766, 0.04239613562822342], [0.03950045630335808, 0.01249300129711628, 0.024573717266321182, 0.033712878823280334, 0.03609582036733627, 0.012554198503494263, 0.05358656123280525, 0.009359144605696201, 0.028025422245264053, 0.012225611135363579, 0.030501263216137886, 0.025835737586021423, 0.009589488618075848, 0.016483237966895103, 0.084063321352005, 0.01602202281355858, 0.02228144370019436, 0.006250270176678896, 0.0365200936794281, 0.006422883365303278, 0.007844123058021069, 0.055222269147634506, 0.009820870123803616, 0.01126785110682249, 0.021959269419312477, 0.09884859621524811, 0.008259588852524757, 0.006706940475851297, 0.029239283874630928, 0.01633574068546295, 0.006648159585893154, 0.012943587265908718, 0.008725474588572979, 0.047615692019462585, 0.026845676824450493, 0.11562033742666245], [0.02913053333759308, 0.011061088182032108, 0.020909370854496956, 0.02996428683400154, 0.03174471855163574, 0.0106118842959404, 0.0449441559612751, 0.007822834886610508, 0.027769125998020172, 0.01040787622332573, 0.027201887220144272, 0.02116522565484047, 0.007662998046725988, 0.014392880722880363, 0.06132799759507179, 0.013879493810236454, 0.0165262371301651, 0.0064588068053126335, 0.03051074407994747, 0.0066957552917301655, 0.007187802344560623, 0.0673983171582222, 0.009856842458248138, 0.011015476658940315, 0.020905064418911934, 0.1137709766626358, 0.007917395792901516, 0.009595567360520363, 0.02761922776699066, 0.014152511954307556, 0.008398817852139473, 0.012949683703482151, 0.007208541035652161, 0.03069131262600422, 0.01935015618801117, 0.07843130081892014, 0.12336315214633942], [0.02417030744254589, 0.011244373396039009, 0.02159697189927101, 0.03764966502785683, 0.06243760511279106, 0.010983810760080814, 0.04911750182509422, 0.009225746616721153, 0.031010005623102188, 0.014673123136162758, 0.031126592308282852, 0.0256684310734272, 0.011818522587418556, 0.023729009553790092, 0.06950945407152176, 0.017961081117391586, 0.016315996646881104, 0.0076661002822220325, 0.03378613293170929, 0.007426184602081776, 0.00827646255493164, 0.04681456834077835, 0.008516071364283562, 0.009144710376858711, 0.019656600430607796, 0.10120239108800888, 0.0063071963377296925, 0.007802621461451054, 0.026857169345021248, 0.01403789035975933, 0.00822308100759983, 0.008876674808561802, 0.007689802907407284, 0.031773023307323456, 0.01819291152060032, 0.06293255090713501, 0.06542964279651642, 0.03114996664226055], [0.023625299334526062, 0.00976650882512331, 0.013427370227873325, 0.019229711964726448, 0.026712464168667793, 0.008511530235409737, 0.030257347971200943, 0.0062660882249474525, 0.014540385454893112, 0.007623175159096718, 0.016182713210582733, 0.014878308400511742, 0.007319650147110224, 0.01730353944003582, 0.04218931123614311, 0.01150145847350359, 0.012445332482457161, 0.01957714557647705, 0.02173645608127117, 0.007651874329894781, 0.007667179685086012, 0.046776361763477325, 0.008552501909434795, 0.00680130859836936, 0.016628429293632507, 0.07525892555713654, 0.006171958055347204, 0.00672014057636261, 0.02320387400686741, 0.011686854995787144, 0.009131746366620064, 0.011457863263785839, 0.007902318611741066, 0.02709449641406536, 0.014077818021178246, 0.04814121127128601, 0.0823177769780159, 0.07660701870918274, 0.18305648863315582], [0.02983459085226059, 0.00876541156321764, 0.015478495508432388, 0.021141869947314262, 0.028333298861980438, 0.007991625927388668, 0.031873103231191635, 0.006998905912041664, 0.020378554239869118, 0.00827453751116991, 0.01865607500076294, 0.01640573889017105, 0.00671016750857234, 0.018084021285176277, 0.05144047737121582, 0.014447595924139023, 0.014228635467588902, 0.01667947508394718, 0.04345915466547012, 0.008857263252139091, 0.008958968333899975, 0.08512511849403381, 0.007791391108185053, 0.009315677918493748, 0.020554352551698685, 0.11197768896818161, 0.0056582228280603886, 0.006070716306567192, 0.0219848845154047, 0.011733817867934704, 0.005927873309701681, 0.007879055105149746, 0.007551038637757301, 0.023876121267676353, 0.008395369164645672, 0.034817423671483994, 0.052583787590265274, 0.036174070090055466, 0.11520995199680328, 0.030375543981790543], [0.041284237056970596, 0.008781597018241882, 0.014768492430448532, 0.020450100302696228, 0.02318144217133522, 0.00769482646137476, 0.030144942924380302, 0.004638934042304754, 0.015627102926373482, 0.006582286674529314, 0.01929810456931591, 0.01438814215362072, 0.005691582337021828, 0.015776431187987328, 0.049784500151872635, 0.009341450408101082, 0.010958125814795494, 0.007668324280530214, 0.05670952424407005, 0.005881089251488447, 0.006704926490783691, 0.06907273083925247, 0.00560866529121995, 0.006354379002004862, 0.017034566029906273, 0.14992497861385345, 0.003772775176912546, 0.004320124164223671, 0.0164119191467762, 0.009169688448309898, 0.004035527352243662, 0.00875986646860838, 0.004575397819280624, 0.01607222855091095, 0.006890163756906986, 0.029388658702373505, 0.03884439170360565, 0.019305776804685593, 0.05248437449336052, 0.02589373290538788, 0.13672392070293427], [0.025878850370645523, 0.007922647520899773, 0.015164638869464397, 0.020796122029423714, 0.024884240701794624, 0.00924538355320692, 0.03706261143088341, 0.006964599713683128, 0.02181232161819935, 0.00884274858981371, 0.023262126371264458, 0.02033206820487976, 0.008248033933341503, 0.013621088117361069, 0.04034150764346123, 0.010296312160789967, 0.014137230813503265, 0.006526845041662455, 0.026690049096941948, 0.005629427265375853, 0.006105534732341766, 0.05993012338876724, 0.007207442540675402, 0.007751126307994127, 0.023198692128062248, 0.07169150561094284, 0.007104802876710892, 0.005934710614383221, 0.029638366773724556, 0.015337328426539898, 0.00618871720507741, 0.0103116724640131, 0.005945871118456125, 0.03045518696308136, 0.012958085164427757, 0.02874944731593132, 0.02029919996857643, 0.014989282004535198, 0.036869749426841736, 0.010980455204844475, 0.06325145065784454, 0.17744244635105133], [0.021101094782352448, 0.007759347558021545, 0.01571401208639145, 0.023843547329306602, 0.029750237241387367, 0.009337883442640305, 0.041181374341249466, 0.006687036249786615, 0.019088920205831528, 0.008862264454364777, 0.027966823428869247, 0.021983664482831955, 0.008948209695518017, 0.017320076003670692, 0.06725183874368668, 0.013977715745568275, 0.01729924976825714, 0.006360906176269054, 0.02956954576075077, 0.004874304868280888, 0.005248177796602249, 0.04804839566349983, 0.008113812655210495, 0.008160565048456192, 0.01733550801873207, 0.10927131026983261, 0.006925970781594515, 0.006499411538243294, 0.028339333832263947, 0.01963910460472107, 0.008336648344993591, 0.01034428458660841, 0.006927895825356245, 0.04203983023762703, 0.012095862999558449, 0.04858672246336937, 0.02594720385968685, 0.010998333804309368, 0.03179777413606644, 0.005774938967078924, 0.02464810200035572, 0.08873103559017181, 0.027311690151691437], [0.02847410924732685, 0.007838752120733261, 0.014425584115087986, 0.022820819169282913, 0.02101278491318226, 0.008090594783425331, 0.03180402144789696, 0.005720345303416252, 0.016739115118980408, 0.007369778119027615, 0.02170374058187008, 0.018655048683285713, 0.007504118140786886, 0.015125450678169727, 0.06309313327074051, 0.019393743947148323, 0.013765685260295868, 0.0071968091651797295, 0.02503790333867073, 0.004892864730209112, 0.005723229143768549, 0.03992506116628647, 0.009264303371310234, 0.011297371238470078, 0.018967030569911003, 0.07153468579053879, 0.006542201153934002, 0.005590933840721846, 0.02073519304394722, 0.01162080280482769, 0.006080196239054203, 0.010978464968502522, 0.004340358544141054, 0.033759705722332, 0.008494654670357704, 0.06160948798060417, 0.03544219583272934, 0.015256649814546108, 0.04435117170214653, 0.005563290324062109, 0.03210841119289398, 0.07290612161159515, 0.017434684559702873, 0.08980940282344818], [0.023875495418906212, 0.008324280381202698, 0.01676822453737259, 0.02313080243766308, 0.02957409992814064, 0.008928481489419937, 0.034959178417921066, 0.005954867694526911, 0.0186776053160429, 0.008419840596616268, 0.022928692400455475, 0.016898537054657936, 0.007292784750461578, 0.015258022584021091, 0.06257279962301254, 0.014270994812250137, 0.011962885968387127, 0.00649029528722167, 0.026599638164043427, 0.004960846621543169, 0.0047897049225866795, 0.04795345291495323, 0.006782170385122299, 0.006961136125028133, 0.014539480209350586, 0.060424137860536575, 0.007315455004572868, 0.005378605332225561, 0.02008294314146042, 0.010759550146758556, 0.006643347442150116, 0.009995614178478718, 0.005966442637145519, 0.03449074178934097, 0.010989979840815067, 0.03529344126582146, 0.022574344649910927, 0.014440908096730709, 0.043270934373140335, 0.006526229437440634, 0.02094792015850544, 0.05471450090408325, 0.01855285093188286, 0.053106460720300674, 0.10965131223201752], [0.04701139032840729, 0.012011763639748096, 0.02035086788237095, 0.024072719737887383, 0.031011752784252167, 0.011480612680315971, 0.04739242047071457, 0.007057922892272472, 0.023368244990706444, 0.009773638099431992, 0.029572870582342148, 0.024299930781126022, 0.010724709369242191, 0.024332396686077118, 0.0321577712893486, 0.011415640823543072, 0.010434090159833431, 0.007279521785676479, 0.014395542442798615, 0.00485839881002903, 0.005411325953900814, 0.04349474608898163, 0.00744286086410284, 0.008135446347296238, 0.024080228060483932, 0.04545501619577408, 0.006542510818690062, 0.004095656331628561, 0.01987125724554062, 0.015155024826526642, 0.006857193075120449, 0.009403699077665806, 0.00463448092341423, 0.02754308097064495, 0.006367674097418785, 0.018542278558015823, 0.015861432999372482, 0.014159445650875568, 0.0486377514898777, 0.003166421316564083, 0.013803715817630291, 0.02527938410639763, 0.0087586073204875, 0.02846771851181984, 0.05068950727581978, 0.1351412683725357], [0.09975061565637589, 0.014223081059753895, 0.02451861836016178, 0.03264414891600609, 0.04479493200778961, 0.009877345524728298, 0.07547002285718918, 0.00842051301151514, 0.03684719651937485, 0.0171255711466074, 0.04008178412914276, 0.03489142656326294, 0.010658619925379753, 0.03315305709838867, 0.03893883153796196, 0.010742067359387875, 0.011416872031986713, 0.0049164132215082645, 0.01800907775759697, 0.00603839848190546, 0.0062896693125367165, 0.04038793593645096, 0.006729696411639452, 0.009881161153316498, 0.013538113795220852, 0.0506141260266304, 0.004194850567728281, 0.004910266026854515, 0.015419200994074345, 0.014109690673649311, 0.00614056596532464, 0.007117789704352617, 0.005054481327533722, 0.016859859228134155, 0.0038593593053519726, 0.010296246968209743, 0.013760125264525414, 0.005924637895077467, 0.02902049571275711, 0.003285905346274376, 0.011484887450933456, 0.02426757849752903, 0.00569903664290905, 0.010263906791806221, 0.02877836301922798, 0.0369156189262867, 0.042677804827690125], [0.03474356606602669, 0.014470912516117096, 0.025459399446845055, 0.0332535058259964, 0.04835524782538414, 0.009535199031233788, 0.06311067193746567, 0.008417968638241291, 0.037445440888404846, 0.014953781850636005, 0.04639142379164696, 0.04134175181388855, 0.00911659188568592, 0.027415355667471886, 0.031752802431583405, 0.011099805124104023, 0.012004981748759747, 0.006594642531126738, 0.01899026706814766, 0.008391340263187885, 0.007167650852352381, 0.04529048129916191, 0.006170907989144325, 0.010058105923235416, 0.016694776713848114, 0.05261877551674843, 0.00427967868745327, 0.0057023316621780396, 0.020379850640892982, 0.008855138905346394, 0.006354381795972586, 0.00983535498380661, 0.006498711183667183, 0.017023945227265358, 0.0048916758969426155, 0.011492464691400528, 0.016527341678738594, 0.016560455784201622, 0.04378417506814003, 0.004118373151868582, 0.012669778428971767, 0.022966155782341957, 0.006322756875306368, 0.010616025887429714, 0.028024569153785706, 0.04414300620555878, 0.03976358100771904, 0.018344838172197342], [0.047492608428001404, 0.013206868432462215, 0.025284383445978165, 0.03450476750731468, 0.05188160762190819, 0.010967062786221504, 0.08303485810756683, 0.006989249028265476, 0.03632153943181038, 0.013828378170728683, 0.03633755072951317, 0.03556478023529053, 0.009209815412759781, 0.02458053268492222, 0.02982148341834545, 0.00788787193596363, 0.010707463137805462, 0.004611768294125795, 0.021408896893262863, 0.006376729346811771, 0.005909270141273737, 0.0379803441464901, 0.007732429075986147, 0.009182333014905453, 0.015634426847100258, 0.05708139017224312, 0.003659059526398778, 0.004725994076579809, 0.015894349664449692, 0.009621065109968185, 0.004784575663506985, 0.009077279828488827, 0.004865379072725773, 0.014689904637634754, 0.00300556980073452, 0.007443372160196304, 0.010748973116278648, 0.006631850730627775, 0.028270823881030083, 0.00294078653678298, 0.011175001040101051, 0.018270030617713928, 0.004537580534815788, 0.008039090782403946, 0.020315062254667282, 0.031042462214827538, 0.026820408180356026, 0.03318937122821808, 0.07671356201171875], [0.04510235786437988, 0.014638680964708328, 0.025409623980522156, 0.04260822385549545, 0.043994028121232986, 0.012055540457367897, 0.11047309637069702, 0.006942081265151501, 0.024375032633543015, 0.01002446934580803, 0.029565414413809776, 0.023615960031747818, 0.007376356981694698, 0.019330408424139023, 0.029968760907649994, 0.0082174614071846, 0.008926328271627426, 0.004823719151318073, 0.016920579597353935, 0.00533269764855504, 0.005953256506472826, 0.03858102113008499, 0.004264535382390022, 0.006471247877925634, 0.01317687053233385, 0.04582805931568146, 0.003273691050708294, 0.00379620841704309, 0.01540686096996069, 0.007669519167393446, 0.004940904676914215, 0.011843213811516762, 0.011790651828050613, 0.014348468743264675, 0.003350412705913186, 0.008949270471930504, 0.011639252305030823, 0.004966771230101585, 0.02015303447842598, 0.003725020680576563, 0.012420179322361946, 0.018669268116354942, 0.00516931526362896, 0.008279695175588131, 0.02409655600786209, 0.025592001155018806, 0.016685616225004196, 0.0245257206261158, 0.08287200331687927, 0.051860518753528595], [0.026955852285027504, 0.009360763244330883, 0.01563074253499508, 0.019674144685268402, 0.030366109684109688, 0.008088156580924988, 0.062187664210796356, 0.005770949646830559, 0.030296247452497482, 0.009378816932439804, 0.023129543289542198, 0.019897889345884323, 0.006030659656971693, 0.01351898442953825, 0.02582797221839428, 0.008646647445857525, 0.008142703212797642, 0.0035906347911804914, 0.02151148021221161, 0.007849235087633133, 0.005583308171480894, 0.08586321026086807, 0.004613630473613739, 0.0043863411992788315, 0.018006540834903717, 0.08122483640909195, 0.002914358163252473, 0.00297124357894063, 0.01909632794559002, 0.00758900074288249, 0.0035439464263617992, 0.005656686145812273, 0.00676919799298048, 0.013069860637187958, 0.002973637543618679, 0.007419851142913103, 0.01110713742673397, 0.006066063418984413, 0.028527621179819107, 0.0025827744975686073, 0.012737681157886982, 0.03192729130387306, 0.003312548855319619, 0.008105194196105003, 0.016652856022119522, 0.024595139548182487, 0.014722543768584728, 0.009602183476090431, 0.03455231338739395, 0.04196911305189133, 0.12600232660770416], [0.03858106955885887, 0.011732667684555054, 0.020348690450191498, 0.02983858808875084, 0.03930381312966347, 0.021778110414743423, 0.04851367324590683, 0.007815578021109104, 0.0230307187885046, 0.011166864074766636, 0.02848093956708908, 0.027432043105363846, 0.013636640273034573, 0.02133893594145775, 0.030853567644953728, 0.008357006125152111, 0.010054351761937141, 0.006336188409477472, 0.018069596961140633, 0.00556298578158021, 0.007082946598529816, 0.04343267157673836, 0.010792032815515995, 0.006058176979422569, 0.01046980544924736, 0.04351440444588661, 0.0033457931131124496, 0.004119297955185175, 0.01286766491830349, 0.009085255675017834, 0.005389842204749584, 0.008344549685716629, 0.005817938130348921, 0.011694595217704773, 0.0031334899831563234, 0.007118099369108677, 0.011041178368031979, 0.010006621479988098, 0.03588394075632095, 0.0028171134181320667, 0.009602272883057594, 0.018141021952033043, 0.005001673940569162, 0.006452590227127075, 0.012736733071506023, 0.02057741768658161, 0.020127831026911736, 0.014730121940374374, 0.04779386520385742, 0.02256048284471035, 0.04396427422761917, 0.10406427830457687], [0.031387459486722946, 0.015259623527526855, 0.01992468349635601, 0.02662709914147854, 0.06872310489416122, 0.013489000499248505, 0.05212916433811188, 0.011493148282170296, 0.033647190779447556, 0.016039537265896797, 0.04692530259490013, 0.04616546630859375, 0.025176746770739555, 0.11961931735277176, 0.03782583028078079, 0.008955612778663635, 0.006058395840227604, 0.003433807985857129, 0.014489298686385155, 0.004708132240921259, 0.0047163874842226505, 0.02828015573322773, 0.005668531637638807, 0.004308914765715599, 0.008131799288094044, 0.03524898737668991, 0.0026006840635091066, 0.002964874729514122, 0.010697757825255394, 0.0065068393014371395, 0.004951030481606722, 0.005276763346046209, 0.003123578615486622, 0.009777619503438473, 0.0026089174207299948, 0.006989248096942902, 0.008900581859052181, 0.0057887183502316475, 0.02182919718325138, 0.0021279065404087305, 0.008258233778178692, 0.01601771079003811, 0.0060609858483076096, 0.005624422803521156, 0.009582565166056156, 0.017538174986839294, 0.014644200913608074, 0.008413945324718952, 0.03123326785862446, 0.01068614237010479, 0.016493843868374825, 0.05100877210497856, 0.0218613650649786], [0.034983642399311066, 0.006946560461074114, 0.015138527378439903, 0.02029646746814251, 0.034087348729372025, 0.007464866619557142, 0.0352475680410862, 0.007043035700917244, 0.019419638440012932, 0.009628538973629475, 0.021814849227666855, 0.023048430681228638, 0.008684083819389343, 0.04771150276064873, 0.14330413937568665, 0.012381203472614288, 0.00853792019188404, 0.0040978542529046535, 0.026233239099383354, 0.004455856513231993, 0.005881000310182571, 0.06067219376564026, 0.005314229987561703, 0.006697984877973795, 0.012392885982990265, 0.03661937639117241, 0.0029452762100845575, 0.0037770697381347418, 0.014735380187630653, 0.007842336781322956, 0.004295347258448601, 0.0055399672128260136, 0.003939120098948479, 0.012772596441209316, 0.0034969972912222147, 0.00989576056599617, 0.012396201491355896, 0.004095722455531359, 0.018978197127580643, 0.003253624541684985, 0.013530529104173183, 0.029902668669819832, 0.004138116259127855, 0.005357612855732441, 0.010548889636993408, 0.019940374419093132, 0.008663247339427471, 0.007123899646103382, 0.019388310611248016, 0.007620113901793957, 0.020902348682284355, 0.03775303438305855, 0.029970532283186913, 0.059093743562698364], [0.02026274986565113, 0.006719354074448347, 0.012157377786934376, 0.01844494603574276, 0.020736169070005417, 0.007120243273675442, 0.03118736669421196, 0.00608812365680933, 0.01716524548828602, 0.007394380401819944, 0.020687896758317947, 0.019250184297561646, 0.006540071684867144, 0.015151453204452991, 0.05928529426455498, 0.02356410212814808, 0.01845904253423214, 0.004131689202040434, 0.017572512850165367, 0.003514608833938837, 0.003153206780552864, 0.036250971257686615, 0.005260361824184656, 0.004982423037290573, 0.009348941966891289, 0.047316133975982666, 0.002850132994353771, 0.003242870094254613, 0.011233553290367126, 0.00602114200592041, 0.004491926170885563, 0.0046926336362957954, 0.0028354257810860872, 0.010025622323155403, 0.002491217805072665, 0.006092552561312914, 0.01000842172652483, 0.0031670446041971445, 0.015021120198071003, 0.002167732687667012, 0.009615489281713963, 0.02744324319064617, 0.005140367895364761, 0.006163475569337606, 0.015138356015086174, 0.019116900861263275, 0.011199211701750755, 0.008188685402274132, 0.02567252889275551, 0.00754750519990921, 0.022478632628917694, 0.047629792243242264, 0.020627589896321297, 0.01122608408331871, 0.236725851893425], [0.017016204074025154, 0.007682042196393013, 0.0130418436601758, 0.02169671654701233, 0.021423814818263054, 0.006701107136905193, 0.03571668267250061, 0.0057726046070456505, 0.01659170538187027, 0.007929446175694466, 0.019258471205830574, 0.01839827001094818, 0.007077256683260202, 0.017802905291318893, 0.05807417631149292, 0.014238283969461918, 0.027539512142539024, 0.011715526692569256, 0.021532533690333366, 0.004473241977393627, 0.004815760999917984, 0.039860110729932785, 0.0059779370203614235, 0.012195160612463951, 0.014054626226425171, 0.04145766422152519, 0.00395161472260952, 0.003314552130177617, 0.011609171517193317, 0.006895784288644791, 0.003883852856233716, 0.0048763444647192955, 0.0032645391765981913, 0.011178969405591488, 0.0031879956368356943, 0.008717580698430538, 0.009504579938948154, 0.004689384717494249, 0.016739824786782265, 0.005323697812855244, 0.011602628976106644, 0.04119078442454338, 0.004174907226115465, 0.007971448823809624, 0.012682770378887653, 0.01982242614030838, 0.011991102248430252, 0.005971377249807119, 0.018315892666578293, 0.009055017493665218, 0.020522011443972588, 0.04629485681653023, 0.010989288799464703, 0.014928234741091728, 0.1711771935224533, 0.024128610268235207], [0.016186900436878204, 0.007116301450878382, 0.011716265231370926, 0.015134993009269238, 0.018847428262233734, 0.006065036170184612, 0.02771717868745327, 0.004735896829515696, 0.020692162215709686, 0.006827071309089661, 0.015945691615343094, 0.013974581845104694, 0.006573436316102743, 0.012768728658556938, 0.049848176538944244, 0.008895553648471832, 0.013013032265007496, 0.007987994700670242, 0.03176150843501091, 0.004407182335853577, 0.004387617111206055, 0.045080769807100296, 0.0043617249466478825, 0.0070111402310431, 0.010683376342058182, 0.042630188167095184, 0.0029567971359938383, 0.0030751987360417843, 0.012152974493801594, 0.005787063855677843, 0.0039656455628573895, 0.00446414016187191, 0.0035535681527107954, 0.01199517585337162, 0.0034596689511090517, 0.010411559604108334, 0.01519244909286499, 0.005960548762232065, 0.018926145508885384, 0.009386952966451645, 0.021240251138806343, 0.09336092323064804, 0.004087864421308041, 0.007223859895020723, 0.015433348715305328, 0.018195156008005142, 0.010188326239585876, 0.005274804309010506, 0.015686847269535065, 0.00737431924790144, 0.01406862773001194, 0.036583926528692245, 0.011527582071721554, 0.011312874965369701, 0.15327265858650208, 0.027055712416768074, 0.022455181926488876], [0.01906944066286087, 0.005958300083875656, 0.015048344619572163, 0.015659328550100327, 0.01647728495299816, 0.0053595807403326035, 0.02566666528582573, 0.0040894765406847, 0.013072122819721699, 0.0049355714581906796, 0.01272435300052166, 0.012867976911365986, 0.004773365333676338, 0.01195637509226799, 0.037355683743953705, 0.007273557595908642, 0.009222464635968208, 0.00464995251968503, 0.027631884440779686, 0.002967691048979759, 0.00403652573004365, 0.046796757727861404, 0.0032680672593414783, 0.004954454954713583, 0.014959060586988926, 0.13058379292488098, 0.0022330351639539003, 0.0023584216833114624, 0.008792759850621223, 0.003914192318916321, 0.0026736794970929623, 0.0030946682672947645, 0.002172990469262004, 0.007452249992638826, 0.0023420758079737425, 0.007828744128346443, 0.011700564064085484, 0.0027588936500251293, 0.011597982607781887, 0.0046014036051929, 0.017544634640216827, 0.09604565799236298, 0.0028475888539105654, 0.0075643910095095634, 0.023921141400933266, 0.014287440106272697, 0.008895568549633026, 0.003581560915336013, 0.011319330893456936, 0.0049357968382537365, 0.012608181685209274, 0.03335021808743477, 0.005554205272346735, 0.007324971258640289, 0.09236738830804825, 0.011453007347881794, 0.03113643452525139, 0.08038276433944702], [0.01868036389350891, 0.005893760826438665, 0.011055871844291687, 0.015526464208960533, 0.01688413694500923, 0.004647297319024801, 0.024357417598366737, 0.0034597287885844707, 0.01192487496882677, 0.005557807628065348, 0.010911667719483376, 0.011468151584267616, 0.004569604992866516, 0.010753754526376724, 0.034852173179388046, 0.006345479749143124, 0.006372409872710705, 0.0033612914849072695, 0.023786477744579315, 0.0035145801957696676, 0.0040234667249023914, 0.05323634296655655, 0.002960375277325511, 0.003612298984080553, 0.01192494761198759, 0.1405707150697708, 0.0021006432361900806, 0.001809683977626264, 0.0074834804981946945, 0.0039956578984856606, 0.0026862300001084805, 0.004038199782371521, 0.002145015634596348, 0.0060294694267213345, 0.0020896224305033684, 0.006023581139743328, 0.007323124911636114, 0.002621613210067153, 0.00993301160633564, 0.0036719960626214743, 0.01421299111098051, 0.07009006291627884, 0.002018087776377797, 0.0040933904238045216, 0.009177428670227528, 0.009096834808588028, 0.007347744889557362, 0.002965311286970973, 0.009866422973573208, 0.0026719991583377123, 0.010379348881542683, 0.024049460887908936, 0.003507304936647415, 0.0044554611667990685, 0.06167106330394745, 0.005577804986387491, 0.012140090577304363, 0.04971478134393692, 0.184761643409729], [0.013795620761811733, 0.005289959721267223, 0.009821146726608276, 0.01509466115385294, 0.015083140693604946, 0.004861706402152777, 0.025720005854964256, 0.003918890375643969, 0.011840242892503738, 0.005926691461354494, 0.011694981716573238, 0.010385639034211636, 0.004873496945947409, 0.009692125953733921, 0.03834424912929535, 0.008640014566481113, 0.010411690920591354, 0.004310098011046648, 0.01679810881614685, 0.002971350448206067, 0.003951499704271555, 0.05201496183872223, 0.0035901411902159452, 0.004545451141893864, 0.007893710397183895, 0.04715670645236969, 0.0023750290274620056, 0.0025264224968850613, 0.00834295991808176, 0.0051609729416668415, 0.002310603391379118, 0.0029871307779103518, 0.0018240530043840408, 0.006458372808992863, 0.001879517687484622, 0.005101773887872696, 0.0076604881323874, 0.0028317514806985855, 0.010143144987523556, 0.003233034862205386, 0.008069473318755627, 0.01936633139848709, 0.0024721226654946804, 0.004905671812593937, 0.010908917523920536, 0.014189758338034153, 0.0068022324703633785, 0.0027398860547691584, 0.010730692185461521, 0.004664687439799309, 0.01490574050694704, 0.03253621980547905, 0.007022569887340069, 0.007433340419083834, 0.1585296392440796, 0.008221416734158993, 0.010880746878683567, 0.029625099152326584, 0.0936238020658493, 0.14091002941131592], [0.014235883951187134, 0.004462751559913158, 0.008681200444698334, 0.01245089154690504, 0.017602745443582535, 0.005430880002677441, 0.02022460661828518, 0.00371229974552989, 0.010391799733042717, 0.005097521003335714, 0.013031406328082085, 0.010898481123149395, 0.006727591156959534, 0.015609593130648136, 0.05445641279220581, 0.00988355278968811, 0.00764257600530982, 0.004736746195703745, 0.012486021965742111, 0.0046709137968719006, 0.0050564901903271675, 0.02824106067419052, 0.004235223401337862, 0.008790422230958939, 0.011968865990638733, 0.046743955463171005, 0.003476000390946865, 0.0032184431329369545, 0.01104876957833767, 0.008372812531888485, 0.004792925901710987, 0.007688031531870365, 0.010154235176742077, 0.011269194073975086, 0.0028434887062758207, 0.009207707829773426, 0.009079101495444775, 0.004088073968887329, 0.01173497922718525, 0.004832425620406866, 0.009043565019965172, 0.0247088260948658, 0.004106500651687384, 0.006266070529818535, 0.012485084123909473, 0.016152217984199524, 0.00908750668168068, 0.0047342730686068535, 0.012542346492409706, 0.005622680764645338, 0.015377964824438095, 0.029243487864732742, 0.007337846793234348, 0.011033289134502411, 0.12032708525657654, 0.017659073695540428, 0.010072248056530952, 0.027450259774923325, 0.0645587369799614, 0.08756352961063385, 0.055351290851831436], [0.042479272931814194, 0.009792530909180641, 0.015763290226459503, 0.02543635107576847, 0.06340646743774414, 0.008628697134554386, 0.029885463416576385, 0.005189557559788227, 0.01530161127448082, 0.008036785759031773, 0.019651902839541435, 0.02114548720419407, 0.011491261422634125, 0.03576933965086937, 0.0282755047082901, 0.014454652555286884, 0.00920793879777193, 0.004833196755498648, 0.018987521529197693, 0.01139175333082676, 0.007333083543926477, 0.035215262323617935, 0.007181371096521616, 0.009862360544502735, 0.01273399405181408, 0.05341300368309021, 0.004173822235316038, 0.004939673468470573, 0.01770150475203991, 0.011972825974225998, 0.005857931450009346, 0.031771961599588394, 0.016095953062176704, 0.009331637993454933, 0.002701089484617114, 0.006288544274866581, 0.006481064949184656, 0.006441305857151747, 0.024189045652747154, 0.0027514358516782522, 0.005705890245735645, 0.012613127008080482, 0.0048003732226789, 0.004610207863152027, 0.009186595678329468, 0.013888268731534481, 0.011252198368310928, 0.0051452466286718845, 0.010540791787207127, 0.005376498214900494, 0.006785002537071705, 0.01991979032754898, 0.007249991409480572, 0.013099725358188152, 0.02780456468462944, 0.009363955818116665, 0.005889526102691889, 0.009766075760126114, 0.021785227581858635, 0.035979315638542175, 0.025767652317881584, 0.05790446698665619], [0.015893522650003433, 0.006482863333076239, 0.007577146869152784, 0.010003923438489437, 0.0542493499815464, 0.0048537529073655605, 0.024803215637803078, 0.0034585040993988514, 0.017756519839167595, 0.005838362965732813, 0.011530723422765732, 0.013091999106109142, 0.006953160744160414, 0.029174184426665306, 0.01992865465581417, 0.010671917349100113, 0.005587555002421141, 0.003458029590547085, 0.00965601671487093, 0.013238208368420601, 0.010410466231405735, 0.02389187179505825, 0.004087781999260187, 0.005904681049287319, 0.00788397528231144, 0.044371604919433594, 0.002633066149428487, 0.003908402752131224, 0.011105610057711601, 0.007509544957429171, 0.004240956157445908, 0.007454190403223038, 0.010055727325379848, 0.019724499434232712, 0.002284300746396184, 0.004260256886482239, 0.005944586358964443, 0.003130843862891197, 0.01651698164641857, 0.0035552778281271458, 0.005802726838737726, 0.014277641661465168, 0.004541066009551287, 0.00434194877743721, 0.009649463929235935, 0.017003899440169334, 0.008115561679005623, 0.006037600804120302, 0.01338995061814785, 0.006533125415444374, 0.010502682067453861, 0.026347815990447998, 0.013667085207998753, 0.03287992253899574, 0.06599364429712296, 0.0161002054810524, 0.00887269340455532, 0.023309342563152313, 0.0497402660548687, 0.07117598503828049, 0.034685466438531876, 0.03757307678461075, 0.04637663811445236], [0.028149226680397987, 0.006627474445849657, 0.009649189189076424, 0.01472978200763464, 0.016015268862247467, 0.004964638501405716, 0.022270992398262024, 0.004066928755491972, 0.012258937582373619, 0.006290400866419077, 0.013614791445434093, 0.013420047238469124, 0.004988821689039469, 0.01560428086668253, 0.052735570818185806, 0.008404477499425411, 0.008628185838460922, 0.003947147633880377, 0.014826220460236073, 0.003075825981795788, 0.0032852385193109512, 0.03219182789325714, 0.004993487149477005, 0.005817024037241936, 0.012261041440069675, 0.058423761278390884, 0.0036919512785971165, 0.002770395250990987, 0.013499732129275799, 0.006200967822223902, 0.003118847729638219, 0.003957283683121204, 0.0026423255912959576, 0.012713623233139515, 0.004194323439151049, 0.012534690089523792, 0.01063451636582613, 0.004856124985963106, 0.014882253482937813, 0.0036231824196875095, 0.01018199697136879, 0.03649166598916054, 0.003122032852843404, 0.008482084609568119, 0.0164847020059824, 0.021939484402537346, 0.008248328231275082, 0.004002139437943697, 0.015223518945276737, 0.005836562253534794, 0.013566100969910622, 0.03960461542010307, 0.0055328477174043655, 0.00897331815212965, 0.1089325100183487, 0.00827556848526001, 0.00902683474123478, 0.02258353866636753, 0.03439580649137497, 0.03581617772579193, 0.01934961788356304, 0.009208076633512974, 0.005008309613913298, 0.06915340572595596], [0.012732869014143944, 0.005153542384505272, 0.009731074795126915, 0.013672314584255219, 0.02167590707540512, 0.005099114961922169, 0.02662358433008194, 0.003977789077907801, 0.01495338324457407, 0.00645087007433176, 0.014421908184885979, 0.014405595138669014, 0.005915821064263582, 0.012347538955509663, 0.05977466702461243, 0.008980270475149155, 0.007471260614693165, 0.004936872515827417, 0.01449290569871664, 0.00407971628010273, 0.004422680474817753, 0.03541563078761101, 0.004249964375048876, 0.005739190615713596, 0.014544015750288963, 0.09632308781147003, 0.0027611267287284136, 0.0034893869888037443, 0.013520551845431328, 0.006315594073385, 0.0034631192684173584, 0.004280513152480125, 0.003096377942711115, 0.010682697407901287, 0.00372262648306787, 0.012444447726011276, 0.013345680199563503, 0.00891097728163004, 0.028935864567756653, 0.003908051643520594, 0.012806197628378868, 0.04200751706957817, 0.003564483253285289, 0.007914384827017784, 0.014730572700500488, 0.021924106404185295, 0.009814079850912094, 0.005961671005934477, 0.015221170149743557, 0.004390710964798927, 0.01033019833266735, 0.03501404821872711, 0.00656181201338768, 0.007612991612404585, 0.07707635313272476, 0.008029158227145672, 0.008212622255086899, 0.0177469402551651, 0.027994316071271896, 0.028993656858801842, 0.011465005576610565, 0.008344309404492378, 0.004415934905409813, 0.04575091227889061, 0.017648249864578247], [0.019253026694059372, 0.005576998461037874, 0.010323828086256981, 0.014613247476518154, 0.015663588419556618, 0.004887180868536234, 0.024013418704271317, 0.00423941807821393, 0.014094083569943905, 0.0057835886254906654, 0.014180907979607582, 0.012859057635068893, 0.00469591561704874, 0.013045796193182468, 0.03615294024348259, 0.005801628343760967, 0.007452945224940777, 0.004255867097526789, 0.012193524278700352, 0.00398012762889266, 0.0034457400906831026, 0.02481466718018055, 0.003945080563426018, 0.005657092202454805, 0.011472627520561218, 0.05497675761580467, 0.0029057436622679234, 0.003104520495980978, 0.011501016095280647, 0.00583183066919446, 0.003367105033248663, 0.005102942232042551, 0.002945256419479847, 0.009614537470042706, 0.0032312211114913225, 0.009523304179310799, 0.011416670866310596, 0.007316771429032087, 0.017519187182188034, 0.003575656795874238, 0.011166182346642017, 0.022412575781345367, 0.003258640179410577, 0.007818900980055332, 0.01200786978006363, 0.016674069687724113, 0.009671696461737156, 0.004795295186340809, 0.013462410308420658, 0.004318644758313894, 0.010231765918433666, 0.03828839585185051, 0.005528192035853863, 0.01033124141395092, 0.07461279630661011, 0.009446444921195507, 0.00643202755600214, 0.013517355546355247, 0.04077818617224693, 0.04049479216337204, 0.012611838057637215, 0.00722779706120491, 0.005926378536969423, 0.04457586258649826, 0.021747734397649765, 0.11832806468009949], [0.01981980726122856, 0.00777242099866271, 0.01342790201306343, 0.01828753389418125, 0.03206145763397217, 0.007020312361419201, 0.03399550914764404, 0.005562136881053448, 0.019657671451568604, 0.007542666047811508, 0.018555741757154465, 0.014109333045780659, 0.007212131749838591, 0.020938053727149963, 0.021917644888162613, 0.006716791074723005, 0.008087217807769775, 0.0034122755751013756, 0.01383484248071909, 0.005568630062043667, 0.004779813811182976, 0.029772579669952393, 0.004310804419219494, 0.0045112622901797295, 0.014656097628176212, 0.04632432386279106, 0.003943724557757378, 0.004727139137685299, 0.016231566667556763, 0.006684159394353628, 0.004078765399754047, 0.007449073251336813, 0.004026283975690603, 0.011609130539000034, 0.004084503278136253, 0.009768284857273102, 0.013373804278671741, 0.008174298331141472, 0.028010737150907516, 0.002940604230388999, 0.01013852283358574, 0.018433285877108574, 0.00376311712898314, 0.0082625113427639, 0.013570652343332767, 0.01905573531985283, 0.012120811268687248, 0.006545338314026594, 0.018447840586304665, 0.003429138334468007, 0.010814493522047997, 0.027966206893324852, 0.007331895641982555, 0.007148453965783119, 0.03259674087166786, 0.004981185309588909, 0.003076103050261736, 0.010004149749875069, 0.0206602830439806, 0.0251601692289114, 0.007438112981617451, 0.00598750589415431, 0.005189069546759129, 0.028450174257159233, 0.015220367349684238, 0.06766960769891739, 0.09158148616552353], [0.01533299870789051, 0.0042402963154017925, 0.008476199582219124, 0.011131350882351398, 0.01692911423742771, 0.005054301582276821, 0.021898815408349037, 0.0035709182266145945, 0.01171468198299408, 0.0051872581243515015, 0.012838413938879967, 0.011789899319410324, 0.0040527465753257275, 0.008464833721518517, 0.04280737787485123, 0.007056002039462328, 0.00742747075855732, 0.003352272557094693, 0.011386646889150143, 0.0033952512312680483, 0.0030234637670218945, 0.023722000420093536, 0.0036643093917518854, 0.0059740724973380566, 0.00903228111565113, 0.05913759768009186, 0.0034469212405383587, 0.0030283937230706215, 0.009077049791812897, 0.006538004148751497, 0.0034696110524237156, 0.007033196277916431, 0.003360538277775049, 0.013762674294412136, 0.0047173695638775826, 0.019650690257549286, 0.013598120771348476, 0.0049562822096049786, 0.014337148517370224, 0.0035699980799108744, 0.012040868401527405, 0.03701033070683479, 0.004520734306424856, 0.015958230942487717, 0.0181483943015337, 0.016163695603609085, 0.007676330395042896, 0.0034687721636146307, 0.010956032201647758, 0.003770251292735338, 0.009195718914270401, 0.023649010807275772, 0.005123113747686148, 0.005637633614242077, 0.08116122335195541, 0.007381033152341843, 0.0075174435041844845, 0.018201230093836784, 0.031324002891778946, 0.02825162373483181, 0.01090195681899786, 0.0075682890601456165, 0.005421341862529516, 0.04021180793642998, 0.00639295531436801, 0.025680935010313988, 0.05105355754494667, 0.07440681755542755], [0.014452585950493813, 0.004656115081161261, 0.009249011054635048, 0.013204926624894142, 0.01548115722835064, 0.004492034204304218, 0.021348442882299423, 0.003453318029642105, 0.012437059544026852, 0.005165901035070419, 0.013685764744877815, 0.010273286141455173, 0.003954821266233921, 0.007904743775725365, 0.02829165942966938, 0.00656514149159193, 0.006505739409476519, 0.003760513151064515, 0.016512272879481316, 0.0032409706618636847, 0.003440145868808031, 0.028905116021633148, 0.003492822637781501, 0.0039654881693422794, 0.012201361358165741, 0.04035591706633568, 0.003190229646861553, 0.0030000845436006784, 0.011787695810198784, 0.006490141618996859, 0.003511841408908367, 0.006232433021068573, 0.0029857398476451635, 0.013379321433603764, 0.006353086791932583, 0.032949142158031464, 0.02368016354739666, 0.00846309307962656, 0.02008643001317978, 0.004852874204516411, 0.01942274160683155, 0.0318174846470356, 0.007796857971698046, 0.033925920724868774, 0.08028154075145721, 0.02116481214761734, 0.004757986404001713, 0.0022903645876795053, 0.00901115033775568, 0.003751093987375498, 0.009926613420248032, 0.018566923215985298, 0.003655878361314535, 0.0058860271237790585, 0.05353328585624695, 0.006257182918488979, 0.003911351785063744, 0.009360909461975098, 0.02752162516117096, 0.025663642212748528, 0.008478476665914059, 0.003871614346280694, 0.0023631565272808075, 0.0200920682400465, 0.004246933851391077, 0.018989553675055504, 0.029626965522766113, 0.03340104594826698, 0.056468237191438675], [0.013796357437968254, 0.004908632021397352, 0.009480173699557781, 0.01189251709729433, 0.01702217012643814, 0.004429460968822241, 0.02092897705733776, 0.0036331673618406057, 0.013003976084291935, 0.004682507831603289, 0.012992010451853275, 0.010367071256041527, 0.004494907334446907, 0.007677028421312571, 0.03909241035580635, 0.005098908208310604, 0.006651913747191429, 0.002931282389909029, 0.011653241701424122, 0.00271219527348876, 0.0029594588559120893, 0.024114301428198814, 0.004212076775729656, 0.004326271824538708, 0.011193634010851383, 0.03582368791103363, 0.0030424417927861214, 0.0027144986670464277, 0.009762314148247242, 0.006047739181667566, 0.003471620613709092, 0.004299054387956858, 0.0022751614451408386, 0.014217792078852654, 0.0033341054804623127, 0.015910854563117027, 0.008832662366330624, 0.0056400178000330925, 0.01903289183974266, 0.0027192006818950176, 0.009604507125914097, 0.017107145860791206, 0.004500917159020901, 0.016564231365919113, 0.044649720191955566, 0.08827996253967285, 0.004963928833603859, 0.0031887716613709927, 0.010026518255472183, 0.0031741366256028414, 0.009712890721857548, 0.019574826583266258, 0.0045163314789533615, 0.005273911170661449, 0.06377050280570984, 0.005223017185926437, 0.0038599141407757998, 0.011150532402098179, 0.023096377030014992, 0.022285571321845055, 0.009597374126315117, 0.005662926007062197, 0.0032875624019652605, 0.026180099695920944, 0.007567915134131908, 0.020818699151277542, 0.029614508152008057, 0.03772725164890289, 0.039135754108428955, 0.058505501598119736]]})\n",
+              "                window.ecco[viz_id] = ecco.interactiveTokens(viz_id, {'tokens': [{'token': 'در', 'token_id': 589, 'type': 'input', 'value': '0.12459614', 'position': 0}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'value': '0.05899072', 'position': 1}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'input', 'value': '0.112841696', 'position': 2}, {'token': ' شگفت', 'token_id': 3844, 'type': 'input', 'value': '0.16566701', 'position': 3}, {'token': ' انگیز', 'token_id': 5904, 'type': 'input', 'value': '0.18307066', 'position': 4}, {'token': '،', 'token_id': 305, 'type': 'input', 'value': '0.0696605', 'position': 5}, {'token': ' پژوهشگران', 'token_id': 4579, 'type': 'input', 'value': '0.2851732', 'position': 6}, {'token': ' توانستند', 'token_id': 7183, 'type': 'output', 'value': '0', 'position': 7}, {'token': ' یک', 'token_id': 367, 'type': 'output', 'value': '0', 'position': 8}, {'token': ' مولکول', 'token_id': 7053, 'type': 'output', 'value': '0', 'position': 9}, {'token': ' RNA', 'token_id': 16789, 'type': 'output', 'value': '0', 'position': 10}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 11}, {'token': ' ویروس', 'token_id': 1816, 'type': 'output', 'value': '0', 'position': 12}, {'token': ' زیکا', 'token_id': 25375, 'type': 'output', 'value': '0', 'position': 13}, {'token': ' را', 'token_id': 330, 'type': 'output', 'value': '0', 'position': 14}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 15}, {'token': ' فردی', 'token_id': 2730, 'type': 'output', 'value': '0', 'position': 16}, {'token': ' به', 'token_id': 303, 'type': 'output', 'value': '0', 'position': 17}, {'token': ' فرد', 'token_id': 1113, 'type': 'output', 'value': '0', 'position': 18}, {'token': ' دیگری', 'token_id': 1145, 'type': 'output', 'value': '0', 'position': 19}, {'token': ' منتقل', 'token_id': 2923, 'type': 'output', 'value': '0', 'position': 20}, {'token': ' کنند', 'token_id': 689, 'type': 'output', 'value': '0', 'position': 21}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 22}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 23}, {'token': ' اتفاق', 'token_id': 1599, 'type': 'output', 'value': '0', 'position': 24}, {'token': ' عجیب', 'token_id': 3595, 'type': 'output', 'value': '0', 'position': 25}, {'token': ' که', 'token_id': 323, 'type': 'output', 'value': '0', 'position': 26}, {'token': ' تقریبا', 'token_id': 1985, 'type': 'output', 'value': '0', 'position': 27}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 28}, {'token': ' میانه', 'token_id': 4720, 'type': 'output', 'value': '0', 'position': 29}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 30}, {'token': 'ی', 'token_id': 269, 'type': 'output', 'value': '0', 'position': 31}, {'token': ' سال', 'token_id': 415, 'type': 'output', 'value': '0', 'position': 32}, {'token': ' 2015', 'token_id': 9109, 'type': 'output', 'value': '0', 'position': 33}, {'token': ' رخ', 'token_id': 2130, 'type': 'output', 'value': '0', 'position': 34}, {'token': ' داده', 'token_id': 658, 'type': 'output', 'value': '0', 'position': 35}, {'token': ' بود', 'token_id': 390, 'type': 'output', 'value': '0', 'position': 36}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 37}, {'token': ' بسیار', 'token_id': 674, 'type': 'output', 'value': '0', 'position': 38}, {'token': ' جالب', 'token_id': 2351, 'type': 'output', 'value': '0', 'position': 39}, {'token': ' توجه', 'token_id': 772, 'type': 'output', 'value': '0', 'position': 40}, {'token': ' است', 'token_id': 329, 'type': 'output', 'value': '0', 'position': 41}, {'token': '؛', 'token_id': 556, 'type': 'output', 'value': '0', 'position': 42}, {'token': ' زیرا', 'token_id': 1846, 'type': 'output', 'value': '0', 'position': 43}, {'token': ' تا', 'token_id': 399, 'type': 'output', 'value': '0', 'position': 44}, {'token': ' پیش', 'token_id': 495, 'type': 'output', 'value': '0', 'position': 45}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 46}, {'token': ' این', 'token_id': 326, 'type': 'output', 'value': '0', 'position': 47}, {'token': ' تصور', 'token_id': 2826, 'type': 'output', 'value': '0', 'position': 48}, {'token': ' می', 'token_id': 310, 'type': 'output', 'value': '0', 'position': 49}, {'token': '\\u200c', 'token_id': 285, 'type': 'output', 'value': '0', 'position': 50}, {'token': 'شد', 'token_id': 424, 'type': 'output', 'value': '0', 'position': 51}, {'token': ' ویروس', 'token_id': 1816, 'type': 'output', 'value': '0', 'position': 52}, {'token': ' زیکا', 'token_id': 25375, 'type': 'output', 'value': '0', 'position': 53}, {'token': ' از', 'token_id': 312, 'type': 'output', 'value': '0', 'position': 54}, {'token': ' یک', 'token_id': 367, 'type': 'output', 'value': '0', 'position': 55}, {'token': ' پشه', 'token_id': 14891, 'type': 'output', 'value': '0', 'position': 56}, {'token': ' نشئت', 'token_id': 35308, 'type': 'output', 'value': '0', 'position': 57}, {'token': ' گرفته', 'token_id': 792, 'type': 'output', 'value': '0', 'position': 58}, {'token': ' باشد', 'token_id': 577, 'type': 'output', 'value': '0', 'position': 59}, {'token': '.', 'token_id': 24, 'type': 'output', 'value': '0', 'position': 60}, {'token': ' اما', 'token_id': 492, 'type': 'output', 'value': '0', 'position': 61}, {'token': ' در', 'token_id': 298, 'type': 'output', 'value': '0', 'position': 62}, {'token': ' صورت', 'token_id': 649, 'type': 'output', 'value': '0', 'position': 63}, {'token': ' صحت', 'token_id': 6083, 'type': 'output', 'value': '0', 'position': 64}, {'token': ' چنین', 'token_id': 1267, 'type': 'output', 'value': '0', 'position': 65}, {'token': ' چیزی', 'token_id': 1426, 'type': 'output', 'value': '0', 'position': 66}, {'token': '،', 'token_id': 305, 'type': 'output', 'value': '0', 'position': 67}, {'token': ' دانشمندان', 'token_id': 3612, 'type': 'output', 'value': '0', 'position': 68}, {'token': ' قادر', 'token_id': 2306, 'type': 'output', 'value': '0', 'position': 69}, {'token': ' بودند', 'token_id': 1146, 'type': 'output', 'value': '0', 'position': 70}], 'attributions': [[0.12459614127874374, 0.0589907206594944, 0.11284169554710388, 0.16566701233386993, 0.18307065963745117, 0.0696604996919632, 0.2851732075214386], [0.2529815137386322, 0.04535181075334549, 0.07425308227539062, 0.09567464143037796, 0.10514038056135178, 0.03693828359246254, 0.16995692253112793, 0.21970336139202118], [0.15232427418231964, 0.05558961629867554, 0.06487555801868439, 0.10506639629602432, 0.09358786046504974, 0.03876924887299538, 0.2239697426557541, 0.18994463980197906, 0.07587271928787231], [0.10416479408740997, 0.03021611087024212, 0.04603811353445053, 0.07484112679958344, 0.08596987277269363, 0.022690078243613243, 0.13322341442108154, 0.08129703998565674, 0.03362403064966202, 0.38793545961380005], [0.04880847781896591, 0.0231622401624918, 0.03712782263755798, 0.05732569098472595, 0.0507839098572731, 0.017206469550728798, 0.0895972028374672, 0.0746329203248024, 0.016689589247107506, 0.15205365419387817, 0.4326120615005493], [0.0784013420343399, 0.02447136677801609, 0.037635840475559235, 0.04916936904191971, 0.058922186493873596, 0.038343898952007294, 0.089069664478302, 0.08586148917675018, 0.026474889367818832, 0.10156935453414917, 0.35797402262687683, 0.05210665613412857], [0.07602772116661072, 0.025262637063860893, 0.03331468999385834, 0.048916853964328766, 0.04952231049537659, 0.02154785580933094, 0.06093193590641022, 0.05077765882015228, 0.01922646164894104, 0.08694818615913391, 0.2387099266052246, 0.031140197068452835, 0.2576735317707062], [0.07080917060375214, 0.02349696308374405, 0.02228398248553276, 0.03310896456241608, 0.03559548407793045, 0.022395271807909012, 0.05328044295310974, 0.04272511228919029, 0.016377324238419533, 0.06443307548761368, 0.10022883862257004, 0.024790387600660324, 0.07003143429756165, 0.4204435646533966], [0.099708192050457, 0.023978274315595627, 0.034844573587179184, 0.04499518871307373, 0.045593712478876114, 0.02105763368308544, 0.07214769721031189, 0.05793411657214165, 0.018171433359384537, 0.08049940317869186, 0.16231487691402435, 0.018503766506910324, 0.1419326663017273, 0.13660404086112976, 0.0417143888771534], [0.05759957432746887, 0.020180504769086838, 0.025413943454623222, 0.035093825310468674, 0.03478282317519188, 0.021151674911379814, 0.05764422565698624, 0.05058042332530022, 0.014423484914004803, 0.06032995507121086, 0.12792828679084778, 0.017272597178816795, 0.1163620725274086, 0.26477640867233276, 0.03721826896071434, 0.05924198403954506], [0.04383831098675728, 0.016796182841062546, 0.024505162611603737, 0.036710627377033234, 0.03142582252621651, 0.01769358664751053, 0.05913127586245537, 0.05890759080648422, 0.01484772004187107, 0.051242753863334656, 0.09331042319536209, 0.013932371512055397, 0.08884351700544357, 0.17413154244422913, 0.032183922827243805, 0.03885793685913086, 0.20364128053188324], [0.04513881728053093, 0.018431395292282104, 0.02319537103176117, 0.03343474119901657, 0.030762281268835068, 0.017931196838617325, 0.05714104697108269, 0.053488340228796005, 0.014715325087308884, 0.051865167915821075, 0.09840762615203857, 0.016507193446159363, 0.06383009999990463, 0.14852923154830933, 0.030167927965521812, 0.038192927837371826, 0.19447314739227295, 0.06378810852766037], [0.040469735860824585, 0.020507147535681725, 0.02554406225681305, 0.04060496389865875, 0.03481050208210945, 0.014785351231694221, 0.05158572271466255, 0.04979085922241211, 0.01281694881618023, 0.04395487159490585, 0.09318181872367859, 0.012017556466162205, 0.04689127206802368, 0.17374995350837708, 0.02248011715710163, 0.020159700885415077, 0.1078588217496872, 0.052611175924539566, 0.13617952167987823], [0.05505736172199249, 0.01965588517487049, 0.02387665957212448, 0.03233099728822708, 0.034954626113176346, 0.017750883474946022, 0.050370726734399796, 0.05974967032670975, 0.01625778153538704, 0.06168689951300621, 0.11363811790943146, 0.014419186860322952, 0.09191948175430298, 0.1085553914308548, 0.022623008117079735, 0.02013479359447956, 0.05888644605875015, 0.028962016105651855, 0.06781131774187088, 0.10135869681835175], [0.06407136470079422, 0.022351540625095367, 0.03516478091478348, 0.05461277440190315, 0.056863728910684586, 0.019441725686192513, 0.06864368915557861, 0.10735636204481125, 0.010044955648481846, 0.03931380808353424, 0.06271376460790634, 0.010340537875890732, 0.062413979321718216, 0.09924459457397461, 0.026679720729589462, 0.00952533632516861, 0.03102688118815422, 0.01206499058753252, 0.02149616740643978, 0.02330481819808483, 0.16332441568374634], [0.06293593347072601, 0.023719172924757004, 0.04484096169471741, 0.04689894616603851, 0.05361379683017731, 0.02099642902612686, 0.08006977289915085, 0.07615523040294647, 0.013140060938894749, 0.03982928767800331, 0.0629565492272377, 0.014239848591387272, 0.04152067005634308, 0.155813068151474, 0.0213130135089159, 0.010399339720606804, 0.032981447875499725, 0.0117741534486413, 0.026547808200120926, 0.020156988874077797, 0.06716983765363693, 0.07292769104242325], [0.14208495616912842, 0.02269715815782547, 0.034101322293281555, 0.05120595172047615, 0.053267743438482285, 0.017664063721895218, 0.08289331942796707, 0.09443490207195282, 0.013874845579266548, 0.05693495646119118, 0.0764387920498848, 0.01666870526969433, 0.032783348113298416, 0.10944703221321106, 0.010075638070702553, 0.007890261709690094, 0.02716200239956379, 0.008090787567198277, 0.0212688148021698, 0.014299334958195686, 0.03337441757321358, 0.03496061637997627, 0.03838104009628296], [0.05541360378265381, 0.024189850315451622, 0.06455729901790619, 0.040177155286073685, 0.04015693813562393, 0.01708126813173294, 0.0738920345902443, 0.0610194057226181, 0.014303836971521378, 0.06944752484560013, 0.09767015278339386, 0.016407471150159836, 0.044368959963321686, 0.07603656500577927, 0.01255666371434927, 0.009707731194794178, 0.03939976915717125, 0.008869394659996033, 0.022745223715901375, 0.01783454790711403, 0.055060580372810364, 0.0509452149271965, 0.03654804080724716, 0.051610734313726425], [0.07795809209346771, 0.02718258649110794, 0.08559254556894302, 0.13590076565742493, 0.094501793384552, 0.0123142683878541, 0.05801397189497948, 0.04178117588162422, 0.007677602116018534, 0.027785930782556534, 0.052316103130578995, 0.0100296251475811, 0.02190161496400833, 0.08282043784856796, 0.008096480742096901, 0.0055265529081225395, 0.017123814672231674, 0.004878033883869648, 0.015107635408639908, 0.01096715871244669, 0.027464304119348526, 0.025326890870928764, 0.02076668106019497, 0.027756787836551666, 0.1012091264128685], [0.09031327813863754, 0.022765565663576126, 0.04793236032128334, 0.06000019982457161, 0.06944668292999268, 0.01726400852203369, 0.06564363837242126, 0.04977063462138176, 0.009256020188331604, 0.032702863216400146, 0.04942885786294937, 0.011061348952353, 0.027711885049939156, 0.07995136827230453, 0.009570164605975151, 0.007153091486543417, 0.019512630999088287, 0.0065969545394182205, 0.019590677693486214, 0.011801597662270069, 0.025472331792116165, 0.020733816549181938, 0.02587086893618107, 0.017852462828159332, 0.04883924871683121, 0.1537574827671051], [0.03608781099319458, 0.018945923075079918, 0.042487792670726776, 0.04656713828444481, 0.04769504442811012, 0.014906643889844418, 0.05467991158366203, 0.05156176537275314, 0.011280180886387825, 0.036731064319610596, 0.053536560386419296, 0.012793175876140594, 0.02740049548447132, 0.10650606453418732, 0.013503862544894218, 0.013049459084868431, 0.02800799161195755, 0.011115698143839836, 0.02049490064382553, 0.016941139474511147, 0.03509649261832237, 0.04442191496491432, 0.023368433117866516, 0.016289599239826202, 0.05264139175415039, 0.12534548342227936, 0.03854404389858246], [0.03995322808623314, 0.015530649572610855, 0.03790297731757164, 0.03939276188611984, 0.04204639792442322, 0.01319812424480915, 0.05220472440123558, 0.054400671273469925, 0.009319848380982876, 0.02958216704428196, 0.051345694810152054, 0.011860890313982964, 0.02289271354675293, 0.08257012069225311, 0.010382406413555145, 0.010675907135009766, 0.029997358098626137, 0.009009827859699726, 0.01862887293100357, 0.016876250505447388, 0.03283550590276718, 0.030682550743222237, 0.023874470964074135, 0.025093650445342064, 0.05740986764431, 0.08162907510995865, 0.02811415120959282, 0.12258915603160858], [0.03468536585569382, 0.01420165877789259, 0.03211149200797081, 0.032070159912109375, 0.04905363917350769, 0.012988066300749779, 0.06332265585660934, 0.05103076249361038, 0.011850827373564243, 0.037792179733514786, 0.057034771889448166, 0.009326977655291557, 0.03012782149016857, 0.11473535746335983, 0.011316077783703804, 0.010254425927996635, 0.02849821373820305, 0.013318863697350025, 0.025286268442869186, 0.016898272559046745, 0.027275821194052696, 0.01847984828054905, 0.02069409005343914, 0.012561870738863945, 0.042942970991134644, 0.07018674165010452, 0.019638678058981895, 0.09062091261148453, 0.04169521480798721], [0.053866248577833176, 0.012108851224184036, 0.028179455548524857, 0.03542815148830414, 0.04263324663043022, 0.010220766067504883, 0.03903697431087494, 0.029196834191679955, 0.007950103841722012, 0.02492797188460827, 0.04748152196407318, 0.009603161364793777, 0.031118594110012054, 0.13128842413425446, 0.008011515252292156, 0.007559305988252163, 0.026399195194244385, 0.007308554369956255, 0.017988214269280434, 0.011886168271303177, 0.019265171140432358, 0.013609516434371471, 0.01590442657470703, 0.007468835450708866, 0.029029574245214462, 0.05243295803666115, 0.019962487742304802, 0.04037617892026901, 0.025904664769768715, 0.19385288655757904], [0.04599115252494812, 0.013908489607274532, 0.02483011595904827, 0.035999953746795654, 0.10849549621343613, 0.015582884661853313, 0.063108891248703, 0.04242251068353653, 0.008760645985603333, 0.029479360207915306, 0.049082182347774506, 0.014809329062700272, 0.02198493666946888, 0.08485385030508041, 0.009264818392693996, 0.007419924717396498, 0.019426025450229645, 0.008494928479194641, 0.019555198028683662, 0.013761098496615887, 0.020577505230903625, 0.02030400186777115, 0.019029656425118446, 0.008807580918073654, 0.02152964286506176, 0.035210996866226196, 0.01037800032645464, 0.025799641385674477, 0.017128532752394676, 0.11914613842964172, 0.06485648453235626], [0.024040933698415756, 0.009581975638866425, 0.022049367427825928, 0.024067798629403114, 0.026212329044938087, 0.009515766985714436, 0.03329095244407654, 0.029496869072318077, 0.006518335081636906, 0.022639969363808632, 0.03966492414474487, 0.00898873433470726, 0.0294137392193079, 0.11951640248298645, 0.009375058114528656, 0.008341385051608086, 0.025370826944708824, 0.010073949582874775, 0.014459243975579739, 0.010891355574131012, 0.019398299977183342, 0.015723804011940956, 0.022033801302313805, 0.008866447024047375, 0.028992842882871628, 0.04630151391029358, 0.02575969509780407, 0.03760502487421036, 0.01851644180715084, 0.20524755120277405, 0.011715947650372982, 0.07632868736982346], [0.03767366707324982, 0.015039918944239616, 0.02620927058160305, 0.04772048071026802, 0.09031621366739273, 0.011375864036381245, 0.056250229477882385, 0.048186443746089935, 0.009212073870003223, 0.03062625043094158, 0.048203323036432266, 0.008911460638046265, 0.025398271158337593, 0.146060511469841, 0.008858838118612766, 0.006686085369437933, 0.021207423880696297, 0.006751825101673603, 0.020831845700740814, 0.012697103433310986, 0.01959266886115074, 0.022235363721847534, 0.024913538247346878, 0.006601069588214159, 0.01883990690112114, 0.02835673652589321, 0.010706198401749134, 0.019131556153297424, 0.010529689490795135, 0.07048661261796951, 0.0111683439463377, 0.02779192291200161, 0.05142926424741745], [0.03604169189929962, 0.011668023653328419, 0.034948285669088364, 0.03281804546713829, 0.03130565583705902, 0.010447677224874496, 0.04213670641183853, 0.02700139209628105, 0.0065635014325380325, 0.021353688091039658, 0.03437703102827072, 0.007233802694827318, 0.02078537829220295, 0.07595853507518768, 0.007737737149000168, 0.0064164442010223866, 0.02091761864721775, 0.006411997601389885, 0.016948409378528595, 0.010640245862305164, 0.018127528950572014, 0.0154121620580554, 0.014997366815805435, 0.012973747216165066, 0.04698353633284569, 0.04701879248023033, 0.016902415081858635, 0.033057134598493576, 0.009617011062800884, 0.061363425105810165, 0.007322527468204498, 0.029062729328870773, 0.04147661104798317, 0.18397320806980133], [0.035244036465883255, 0.013265511021018028, 0.029235417023301125, 0.024144329130649567, 0.028328241780400276, 0.009090706706047058, 0.032675858587026596, 0.02889280766248703, 0.005860803183168173, 0.019728869199752808, 0.030791033059358597, 0.008044430054724216, 0.0166948102414608, 0.05510980635881424, 0.007309436798095703, 0.0058751716278493404, 0.0141866160556674, 0.005389383994042873, 0.014450306072831154, 0.009253846481442451, 0.016972966492176056, 0.01589118503034115, 0.015533221885561943, 0.009026098996400833, 0.03414662182331085, 0.046254731714725494, 0.015892591327428818, 0.02647286280989647, 0.009996041655540466, 0.050081752240657806, 0.006090652663260698, 0.021127454936504364, 0.027765506878495216, 0.10648858547210693, 0.20468828082084656], [0.027601487934589386, 0.011068012565374374, 0.023422006517648697, 0.021514328196644783, 0.028658172115683556, 0.012046508491039276, 0.03697385638952255, 0.07035086303949356, 0.006737875286489725, 0.01986510679125786, 0.03480121120810509, 0.00996313150972128, 0.015486272983253002, 0.05861137434840202, 0.009244811721146107, 0.005739608313888311, 0.016340889036655426, 0.00562829477712512, 0.01504586823284626, 0.011982698924839497, 0.027964511886239052, 0.05135392025113106, 0.015523246489465237, 0.011201952584087849, 0.026242854073643684, 0.04561332240700722, 0.01202515047043562, 0.016214830800890923, 0.006935405544936657, 0.04012409970164299, 0.0058925217017531395, 0.020242540165781975, 0.019840287044644356, 0.08222771435976028, 0.10025627911090851, 0.07725901156663895], [0.05833694711327553, 0.014158246107399464, 0.02876315824687481, 0.033423684537410736, 0.04076646640896797, 0.01844620518386364, 0.043657321482896805, 0.03732679411768913, 0.008903338573873043, 0.02446647360920906, 0.03982466831803322, 0.013412076979875565, 0.02048288658261299, 0.07103263586759567, 0.009610350243747234, 0.0073249158449471, 0.016790714114904404, 0.006938905455172062, 0.013930238783359528, 0.009098909795284271, 0.018728679046034813, 0.021245166659355164, 0.01960105262696743, 0.011922354809939861, 0.03370649740099907, 0.061837006360292435, 0.02578432857990265, 0.01772122085094452, 0.00579717056825757, 0.04632611200213432, 0.0065526640973985195, 0.025040794163942337, 0.011512059718370438, 0.06517720967531204, 0.04201703518629074, 0.032564904540777206, 0.03777075186371803], [0.028437528759241104, 0.012858198024332523, 0.029058517888188362, 0.03170205280184746, 0.04011141508817673, 0.013798587024211884, 0.04584014415740967, 0.040225908160209656, 0.007829546928405762, 0.029606079682707787, 0.04365178570151329, 0.011106550693511963, 0.025627167895436287, 0.08597414940595627, 0.010356421582400799, 0.008077251724898815, 0.019075661897659302, 0.007137411739677191, 0.018252382054924965, 0.012172051705420017, 0.02340644970536232, 0.023407790809869766, 0.01955839805305004, 0.01104331761598587, 0.04047297313809395, 0.07283547520637512, 0.016371440142393112, 0.016498100012540817, 0.007379240822046995, 0.03843194618821144, 0.005098860245198011, 0.014634750783443451, 0.009548225440084934, 0.04679559916257858, 0.0391664057970047, 0.02607959881424904, 0.04156367853283882, 0.026808975264430046], [0.029285229742527008, 0.01536040473729372, 0.03850794956088066, 0.06648729741573334, 0.04815235361456871, 0.009091353975236416, 0.03638817369937897, 0.03172880783677101, 0.00734717445448041, 0.02415931411087513, 0.035243622958660126, 0.007798622362315655, 0.02076129987835884, 0.05787219479680061, 0.006526454817503691, 0.006237529218196869, 0.01621832884848118, 0.0051058027893304825, 0.014551497995853424, 0.011892206035554409, 0.0233645997941494, 0.016932757571339607, 0.012282217852771282, 0.01096659991890192, 0.04553016647696495, 0.07408188283443451, 0.012605915777385235, 0.016059326007962227, 0.005145110655575991, 0.029473496600985527, 0.0038962368853390217, 0.017446832731366158, 0.010241246782243252, 0.039750322699546814, 0.042794644832611084, 0.02511938475072384, 0.024909203872084618, 0.018581561744213104, 0.08210281282663345], [0.025081146508455276, 0.010696264915168285, 0.026332659646868706, 0.03884657844901085, 0.026304462924599648, 0.010357419028878212, 0.03634653985500336, 0.022793494164943695, 0.005623409058898687, 0.018504543229937553, 0.024887459352612495, 0.006949122529476881, 0.011938598938286304, 0.03469231352210045, 0.006190435495227575, 0.004945534281432629, 0.01227620430290699, 0.004502475261688232, 0.011648940853774548, 0.00798347033560276, 0.015596412122249603, 0.013717025518417358, 0.014615754596889019, 0.009478295221924782, 0.028448326513171196, 0.07259123772382736, 0.011988162063062191, 0.015080996789038181, 0.0038183259312063456, 0.02638481929898262, 0.005372445099055767, 0.01182058546692133, 0.009235185571014881, 0.03601161763072014, 0.028316838666796684, 0.017553744837641716, 0.021606391295790672, 0.012329785153269768, 0.06050562113523483, 0.2386273890733719], [0.02057763747870922, 0.008408510126173496, 0.019716160371899605, 0.02914506196975708, 0.02360595017671585, 0.010037314146757126, 0.03197287768125534, 0.03232477605342865, 0.006157880648970604, 0.016859527677297592, 0.026519006118178368, 0.007919896394014359, 0.013240357860922813, 0.045707494020462036, 0.007345430552959442, 0.005190914496779442, 0.013738654553890228, 0.00495350593701005, 0.011897091753780842, 0.009101996198296547, 0.01672924868762493, 0.013196046464145184, 0.017207838594913483, 0.010146953165531158, 0.03055487386882305, 0.045819640159606934, 0.013989236205816269, 0.017307300120592117, 0.006032575853168964, 0.03534785658121109, 0.00826504360884428, 0.0166028942912817, 0.013835528865456581, 0.06889394670724869, 0.04260680824518204, 0.031218094751238823, 0.04255964607000351, 0.013244054280221462, 0.0362643301486969, 0.10670078545808792, 0.06905720382928848], [0.027713503688573837, 0.011387662030756474, 0.02158042974770069, 0.023335345089435577, 0.04097602143883705, 0.0111611969769001, 0.05226196348667145, 0.03983861207962036, 0.008838998153805733, 0.026737971231341362, 0.04105883836746216, 0.009721953421831131, 0.019474808126688004, 0.06834874302148819, 0.008369406685233116, 0.007217615842819214, 0.018741220235824585, 0.006693869363516569, 0.01839442364871502, 0.012550384737551212, 0.018615489825606346, 0.014534372836351395, 0.018478751182556152, 0.00804912205785513, 0.025074439123272896, 0.033902447670698166, 0.013316688127815723, 0.021913520991802216, 0.00555050652474165, 0.038733869791030884, 0.008567829616367817, 0.030478263273835182, 0.013545759953558445, 0.06414539366960526, 0.028259573504328728, 0.012089774012565613, 0.016408400610089302, 0.012074450962245464, 0.02035512961447239, 0.04908019304275513, 0.03707296401262283, 0.035350143909454346], [0.02219082973897457, 0.008725222200155258, 0.013558315113186836, 0.0173980500549078, 0.04555784538388252, 0.00839065108448267, 0.06838790327310562, 0.024586983025074005, 0.006340003572404385, 0.01962820440530777, 0.027249397709965706, 0.006376071833074093, 0.014000446535646915, 0.04841587692499161, 0.006827497389167547, 0.004100009799003601, 0.012960967607796192, 0.0036829225718975067, 0.012688116170465946, 0.009065003134310246, 0.015085579827427864, 0.010141848586499691, 0.012759252451360226, 0.005907940212637186, 0.015196302905678749, 0.027661656960844994, 0.006369775626808405, 0.016147207468748093, 0.003769477130845189, 0.02753061056137085, 0.011973530985414982, 0.05581014230847359, 0.007927964441478252, 0.12062345445156097, 0.02108742482960224, 0.009680798277258873, 0.012278851121664047, 0.006784271448850632, 0.014518837444484234, 0.04924531280994415, 0.03515886887907982, 0.022693544626235962, 0.11151700466871262], [0.02504323050379753, 0.00969410128891468, 0.016988418996334076, 0.019870877265930176, 0.026428934186697006, 0.00892195850610733, 0.0374847836792469, 0.026577165350317955, 0.006088499911129475, 0.025226309895515442, 0.05558403953909874, 0.007607693783938885, 0.022826915606856346, 0.1231093779206276, 0.006157378200441599, 0.005849852226674557, 0.02603822574019432, 0.004318992141634226, 0.012091124430298805, 0.008141692727804184, 0.021251723170280457, 0.010085966438055038, 0.010824163444340229, 0.007767914794385433, 0.018027404323220253, 0.02872278168797493, 0.008219948038458824, 0.017761358991265297, 0.006005352828651667, 0.03565627336502075, 0.005344239063560963, 0.018114101141691208, 0.014003239572048187, 0.04256901144981384, 0.018592247739434242, 0.010186499916017056, 0.01096621248871088, 0.00427996227517724, 0.011803898960351944, 0.044851914048194885, 0.02472340129315853, 0.014337478205561638, 0.03753594309091568, 0.10431939363479614], [0.024230461567640305, 0.009675081819295883, 0.019172538071870804, 0.021206792443990707, 0.032636355608701706, 0.006988095585256815, 0.045105427503585815, 0.036215074360370636, 0.007050504442304373, 0.02513193152844906, 0.03693537414073944, 0.006251859944313765, 0.0196780264377594, 0.0728691890835762, 0.009222671389579773, 0.005548407789319754, 0.016160039231181145, 0.004879340063780546, 0.014870191924273968, 0.01112388726323843, 0.01774810068309307, 0.012725344859063625, 0.02041388675570488, 0.006519473157823086, 0.022142156958580017, 0.03487618267536163, 0.008555649779736996, 0.019976738840341568, 0.005759235471487045, 0.03858894109725952, 0.0059962705709040165, 0.0218976903706789, 0.016714246943593025, 0.07101621478796005, 0.024621780961751938, 0.011118249036371708, 0.012045089155435562, 0.004812785889953375, 0.011757279746234417, 0.029511116445064545, 0.016946811228990555, 0.01150855328887701, 0.028827309608459473, 0.07808324694633484, 0.04288638383150101], [0.02812175638973713, 0.01158537995070219, 0.02084067091345787, 0.025751136243343353, 0.03269927203655243, 0.008018809370696545, 0.038325175642967224, 0.02868252992630005, 0.007170676253736019, 0.020321615040302277, 0.031764958053827286, 0.007407699711620808, 0.017909754067659378, 0.06645021587610245, 0.010611985810101032, 0.005245007108896971, 0.013611900620162487, 0.00461521465331316, 0.012834100052714348, 0.009187111631035805, 0.01620488613843918, 0.011454823426902294, 0.0173179991543293, 0.005256269127130508, 0.01944746822118759, 0.025447966530919075, 0.007920621894299984, 0.017212385311722755, 0.005243086721748114, 0.03426262363791466, 0.018514389172196388, 0.017513932660222054, 0.01602586917579174, 0.050744712352752686, 0.018508480861783028, 0.009496930986642838, 0.012465178966522217, 0.005057826172560453, 0.011942282319068909, 0.028276558965444565, 0.018484629690647125, 0.010386194102466106, 0.023789165541529655, 0.061626192182302475, 0.045663416385650635, 0.09058116376399994], [0.027811458334326744, 0.008201086893677711, 0.015917165204882622, 0.016584627330303192, 0.01877986639738083, 0.00747892539948225, 0.03416436165571213, 0.027171026915311813, 0.005287014879286289, 0.018251553177833557, 0.029317893087863922, 0.007057914510369301, 0.021151995286345482, 0.10540813207626343, 0.005714257713407278, 0.02476802095770836, 0.011111817322671413, 0.006884687580168247, 0.00963854230940342, 0.00788890477269888, 0.016061754897236824, 0.008526066318154335, 0.01294788159430027, 0.005716969259083271, 0.016330888494849205, 0.02159951813519001, 0.008624372072517872, 0.014169714413583279, 0.004712936468422413, 0.03461718559265137, 0.007561220321804285, 0.016577744856476784, 0.017899302765727043, 0.06271903961896896, 0.023954985663294792, 0.01298450492322445, 0.014003419317305088, 0.006770739331841469, 0.010458176024258137, 0.022128786891698837, 0.015475043095648289, 0.009323101490736008, 0.02251555025577545, 0.06171436980366707, 0.02271157316863537, 0.08981070667505264, 0.03149521350860596], [0.034403372555971146, 0.011623941361904144, 0.02041550725698471, 0.02791854925453663, 0.025889655575156212, 0.010045964270830154, 0.04325075075030327, 0.02995152957737446, 0.007916901260614395, 0.02983730472624302, 0.052953727543354034, 0.008830579929053783, 0.024166038259863853, 0.09476833045482635, 0.006277214270085096, 0.008307760581374168, 0.017546890303492546, 0.004592827055603266, 0.009802861139178276, 0.006623324006795883, 0.029474740847945213, 0.010343613103032112, 0.010972361080348492, 0.014496462419629097, 0.015153986401855946, 0.027309387922286987, 0.008804927580058575, 0.010557379573583603, 0.004547336138784885, 0.025207342579960823, 0.0063643609173595905, 0.011968705803155899, 0.013777375221252441, 0.04222343862056732, 0.022280171513557434, 0.007290498353540897, 0.009069586172699928, 0.005051426123827696, 0.010351640172302723, 0.027557963505387306, 0.015767009928822517, 0.011153211817145348, 0.019338298588991165, 0.050397682934999466, 0.01721218228340149, 0.05701940134167671, 0.011913727968931198, 0.029272815212607384], [0.018258268013596535, 0.007290055975317955, 0.012981018982827663, 0.01735704205930233, 0.01827934756875038, 0.005982641596347094, 0.0325055755674839, 0.022229786962270737, 0.006327094975858927, 0.017403272911906242, 0.02990536205470562, 0.005576396360993385, 0.020101632922887802, 0.054860904812812805, 0.004468329716473818, 0.006608421448618174, 0.01198847871273756, 0.003620073664933443, 0.009208772331476212, 0.007226428482681513, 0.027357110753655434, 0.008479917421936989, 0.008653385564684868, 0.012876119464635849, 0.014150038361549377, 0.02120230719447136, 0.00621135625988245, 0.01062352117151022, 0.0035819862969219685, 0.01733824983239174, 0.004828950390219688, 0.010421257466077805, 0.0076513285748660564, 0.022321635857224464, 0.016678504645824432, 0.006898232735693455, 0.006990536581724882, 0.003693764563649893, 0.00851915217936039, 0.02567405439913273, 0.013018470257520676, 0.0075001041404902935, 0.01557284314185381, 0.04480397701263428, 0.01368495263159275, 0.06458009779453278, 0.02027972787618637, 0.06954848021268845, 0.19468100368976593], [0.05826881527900696, 0.0094884829595685, 0.014219020493328571, 0.03258349373936653, 0.04460630193352699, 0.009473326615989208, 0.023432740941643715, 0.019895503297448158, 0.005379727575927973, 0.016232594847679138, 0.02493196912109852, 0.009224793873727322, 0.021287916228175163, 0.06416194140911102, 0.008032456040382385, 0.007411929313093424, 0.011156977154314518, 0.006839051377028227, 0.009744576178491116, 0.007939289323985577, 0.03208569064736366, 0.009250571019947529, 0.011769198812544346, 0.005690636113286018, 0.008405644446611404, 0.014799166470766068, 0.00641009584069252, 0.008579844608902931, 0.004705409053713083, 0.020795971155166626, 0.015497417189180851, 0.011856567114591599, 0.007362247910350561, 0.03432301804423332, 0.017653679475188255, 0.009352926164865494, 0.016036922112107277, 0.008900556713342667, 0.00726683996617794, 0.017865711823105812, 0.015946680679917336, 0.02160886861383915, 0.018927253782749176, 0.028972143307328224, 0.014983744360506535, 0.02484077587723732, 0.012426158413290977, 0.016170967370271683, 0.078261598944664, 0.09494280070066452], [0.015201964415609837, 0.007068500854074955, 0.011724704876542091, 0.01374205481261015, 0.0463721863925457, 0.00706509780138731, 0.055827297270298004, 0.026116088032722473, 0.005737558472901583, 0.015799781307578087, 0.02364811673760414, 0.0065473453141748905, 0.011907107196748257, 0.03806501254439354, 0.004976955242455006, 0.005470470990985632, 0.011670357547700405, 0.0038845378439873457, 0.010206630453467369, 0.007996639236807823, 0.013032062910497189, 0.009925971738994122, 0.011535881087183952, 0.007890856824815273, 0.012254010885953903, 0.019813723862171173, 0.004687055014073849, 0.01238082442432642, 0.0039427499286830425, 0.021017994731664658, 0.014986993744969368, 0.04781002551317215, 0.0077330972999334335, 0.043144967406988144, 0.01829061657190323, 0.008692046627402306, 0.011046255007386208, 0.005306249018758535, 0.007556980475783348, 0.02095170132815838, 0.021388478577136993, 0.010002369061112404, 0.03070264868438244, 0.0374312698841095, 0.009889597073197365, 0.032535843551158905, 0.008054913952946663, 0.024852629750967026, 0.09951009601354599, 0.05275336652994156, 0.041850317269563675], [0.029845967888832092, 0.009356853552162647, 0.011831148527562618, 0.017901089042425156, 0.018153132870793343, 0.008945891633629799, 0.023922964930534363, 0.025492949411273003, 0.006635240279138088, 0.04066052287817001, 0.06464426219463348, 0.009255664423108101, 0.07406419515609741, 0.19371077418327332, 0.004616754595190287, 0.005177694838494062, 0.020497579127550125, 0.0027737615164369345, 0.0063100638799369335, 0.004263404291123152, 0.026006609201431274, 0.006415397860109806, 0.006229278165847063, 0.00301797641441226, 0.006784028373658657, 0.010587072931230068, 0.004864447750151157, 0.006039727013558149, 0.001957525033503771, 0.011962147429585457, 0.0025379862636327744, 0.00606742175295949, 0.004591267090290785, 0.017935214564204216, 0.0068971230648458, 0.004653469659388065, 0.00620429078117013, 0.0027531504165381193, 0.0041602239944040775, 0.013698910363018513, 0.0068175517953932285, 0.005964879412204027, 0.0076668839901685715, 0.02024681307375431, 0.005466714967042208, 0.010654945857822895, 0.004744573496282101, 0.00738628301769495, 0.08367031067609787, 0.033194467425346375, 0.0055319503881037235, 0.07723145931959152], [0.014805791899561882, 0.005431131459772587, 0.009314880706369877, 0.01318663265556097, 0.01605967804789543, 0.006286265794187784, 0.025392545387148857, 0.018600601702928543, 0.005151634104549885, 0.025477418676018715, 0.05498684570193291, 0.006903030443936586, 0.05389771983027458, 0.2963863015174866, 0.004005300812423229, 0.003327252110466361, 0.008731693960726261, 0.0025601405650377274, 0.006495229434221983, 0.004389557056128979, 0.014246001839637756, 0.00503295985981822, 0.005506354849785566, 0.0032687450293451548, 0.007569681853055954, 0.010592901147902012, 0.004452903755009174, 0.007211495190858841, 0.001844224170781672, 0.011108104139566422, 0.0030599008314311504, 0.007294662296772003, 0.005294982343912125, 0.027103455737233162, 0.008321686647832394, 0.0055191232822835445, 0.00740584684535861, 0.00226288172416389, 0.003572826273739338, 0.011371280066668987, 0.007220237981528044, 0.005492098163813353, 0.008589747361838818, 0.019333845004439354, 0.005982281640172005, 0.011677997186779976, 0.003320471616461873, 0.005713593680411577, 0.04442286118865013, 0.023654546588659286, 0.007437773048877716, 0.05416572093963623, 0.06955922394990921], [0.030886560678482056, 0.0069791171699762344, 0.010621068999171257, 0.012948300689458847, 0.014100627042353153, 0.00769401527941227, 0.021502038463950157, 0.02052539959549904, 0.004282786510884762, 0.02285405434668064, 0.04192390665411949, 0.006638410501182079, 0.033111121505498886, 0.10335128009319305, 0.0120385205373168, 0.013448713347315788, 0.01225946843624115, 0.0021273992024362087, 0.005671870429068804, 0.004247742705047131, 0.012734374031424522, 0.0034433752298355103, 0.004684022627770901, 0.0026385087985545397, 0.0069176144897937775, 0.010009931400418282, 0.004753479268401861, 0.005579655524343252, 0.001836660085245967, 0.01411060057580471, 0.0028210857417434454, 0.007763805333524942, 0.0067834327928721905, 0.017043817788362503, 0.00741729699075222, 0.003945589996874332, 0.004987186752259731, 0.002029894618317485, 0.003356597851961851, 0.01059208158403635, 0.007196095772087574, 0.006216209381818771, 0.007541321218013763, 0.017565777525305748, 0.004815485794097185, 0.01597539335489273, 0.004997907672077417, 0.007993407547473907, 0.07559744268655777, 0.035558462142944336, 0.0047532422468066216, 0.06716419756412506, 0.043441664427518845, 0.1805219054222107], [0.03678257763385773, 0.008460587821900845, 0.012341314926743507, 0.017171287909150124, 0.018935400992631912, 0.00777228781953454, 0.031141022220253944, 0.02418048307299614, 0.006672105751931667, 0.023711957037448883, 0.04684443771839142, 0.006352630909532309, 0.03492925688624382, 0.09754712134599686, 0.00863850861787796, 0.013105696998536587, 0.051307424902915955, 0.004857450257986784, 0.009917285293340683, 0.008166548795998096, 0.0306437686085701, 0.006252396386116743, 0.00885247066617012, 0.0029372177086770535, 0.009506803005933762, 0.013382675126194954, 0.006116298958659172, 0.008002613671123981, 0.0031533902511000633, 0.02127489075064659, 0.003469158662483096, 0.010877970606088638, 0.006873830687254667, 0.02029469795525074, 0.010801443830132484, 0.005380368325859308, 0.006281590089201927, 0.0035631461068987846, 0.005411828402429819, 0.014275015331804752, 0.010393493808805943, 0.007020364049822092, 0.009569293819367886, 0.020363373681902885, 0.005839608609676361, 0.01858023926615715, 0.009311226196587086, 0.007450100965797901, 0.047129079699516296, 0.0215318500995636, 0.005302398465573788, 0.04272808879613876, 0.039412982761859894, 0.06792821735143661, 0.021252693608403206], [0.020883696153759956, 0.011231882497668266, 0.011988221667706966, 0.014069569297134876, 0.01919497549533844, 0.006798054091632366, 0.02941402606666088, 0.022818943485617638, 0.012575415894389153, 0.03311750292778015, 0.06685224920511246, 0.00566851207986474, 0.044391926378011703, 0.17788606882095337, 0.006548765115439892, 0.006877278909087181, 0.03682956472039223, 0.004983730148524046, 0.01057633850723505, 0.01123303547501564, 0.01775171607732773, 0.005331262014806271, 0.005699256435036659, 0.003046506317332387, 0.009038293734192848, 0.012877743691205978, 0.005152946803718805, 0.007081237155944109, 0.0022219547536224127, 0.012519066222012043, 0.004914190620183945, 0.010167332366108894, 0.004644419532269239, 0.018556110560894012, 0.0092964181676507, 0.004754948429763317, 0.004787215497344732, 0.002499803202226758, 0.0046852221712470055, 0.010919508524239063, 0.007328919135034084, 0.005055148154497147, 0.010349984280765057, 0.015537272207438946, 0.0038022773806005716, 0.013576743192970753, 0.003973009530454874, 0.0064732967875897884, 0.03816528245806694, 0.014428729191422462, 0.0064849285408854485, 0.03393794596195221, 0.02937316708266735, 0.06204122677445412, 0.018887773156166077, 0.02069932594895363], [0.01547426637262106, 0.00634113559499383, 0.011428107507526875, 0.018634630367159843, 0.029027409851551056, 0.005275502800941467, 0.023331576958298683, 0.015509066171944141, 0.004711255896836519, 0.014731685630977154, 0.02882581576704979, 0.005399148445576429, 0.025954745709896088, 0.066549152135849, 0.005565768573433161, 0.005918659269809723, 0.01385867316275835, 0.004747435450553894, 0.0070851570926606655, 0.0060874950140714645, 0.015157492831349373, 0.005345547571778297, 0.007506800349801779, 0.003145994385704398, 0.007676109671592712, 0.01053087878972292, 0.007609982043504715, 0.008814141154289246, 0.004865539725869894, 0.045600809156894684, 0.009695664048194885, 0.02469647489488125, 0.004269601311534643, 0.020519638434052467, 0.006183835677802563, 0.0029936903156340122, 0.0032773574348539114, 0.0018836832605302334, 0.0029743111226707697, 0.007110999897122383, 0.004814234096556902, 0.003390687983483076, 0.005880820564925671, 0.01082239393144846, 0.0034115707967430353, 0.010294527746737003, 0.004966136999428272, 0.0066019585356116295, 0.019016381353139877, 0.008700346574187279, 0.003057644935324788, 0.02126944623887539, 0.026049772277474403, 0.06833743304014206, 0.009629352949559689, 0.008535618893802166, 0.2709065079689026], [0.013592551462352276, 0.00599918095394969, 0.01006416603922844, 0.012329496443271637, 0.02813711203634739, 0.0048746890388429165, 0.024429572746157646, 0.017215022817254066, 0.004544838797301054, 0.014228603802621365, 0.024712752550840378, 0.004066605120897293, 0.012155553326010704, 0.04097880423069, 0.003812947077676654, 0.0038307514041662216, 0.010077943094074726, 0.0029964169953018427, 0.008472763933241367, 0.005747221410274506, 0.009787751361727715, 0.006946276873350143, 0.006507911719381809, 0.003158428706228733, 0.009606707841157913, 0.01484742108732462, 0.003785130102187395, 0.007612478453665972, 0.0023041630629450083, 0.015318360179662704, 0.004938979633152485, 0.015615267679095268, 0.006332491058856249, 0.03514596074819565, 0.010721327736973763, 0.0047446549870073795, 0.005995329935103655, 0.0031610371079295874, 0.004953596740961075, 0.012422970496118069, 0.008261515758931637, 0.006195018067955971, 0.012316468171775341, 0.015119776129722595, 0.003459387691691518, 0.008322403766214848, 0.0033370282035320997, 0.004318542778491974, 0.016400102525949478, 0.008095119148492813, 0.0078207952901721, 0.014220540411770344, 0.011174238286912441, 0.038669437170028687, 0.006987564265727997, 0.005054570734500885, 0.05493425950407982, 0.33914005756378174], [0.008506502956151962, 0.0035799802280962467, 0.006399978883564472, 0.008075806312263012, 0.008857548236846924, 0.003758150152862072, 0.012013768777251244, 0.01782805472612381, 0.0027874098159372807, 0.007631024345755577, 0.013193740509450436, 0.003612624015659094, 0.008501802571117878, 0.026905229315161705, 0.0032098121009767056, 0.0030598416924476624, 0.0058018905110657215, 0.0023701279424130917, 0.004668392241001129, 0.003910496365278959, 0.007240586914122105, 0.00505600543692708, 0.005608804523944855, 0.002970050321891904, 0.0077426983043551445, 0.01017241831868887, 0.007786024361848831, 0.006552138365805149, 0.0022231002803891897, 0.012413798831403255, 0.005072384607046843, 0.009500635787844658, 0.005244510713964701, 0.027141306549310684, 0.017635026946663857, 0.010588192380964756, 0.01092529110610485, 0.0029496452771127224, 0.004896586760878563, 0.013197514228522778, 0.007092619314789772, 0.008849356323480606, 0.009337110444903374, 0.020220644772052765, 0.004987758584320545, 0.012312603183090687, 0.004545490723103285, 0.01381577830761671, 0.1169208511710167, 0.07195977121591568, 0.00519899558275938, 0.10851336270570755, 0.010284782387316227, 0.030598672106862068, 0.005682629533112049, 0.004927285015583038, 0.03300836309790611, 0.13651657104492188, 0.06563841551542282], [0.016587043181061745, 0.007398807909339666, 0.013290895149111748, 0.016470951959490776, 0.023100052028894424, 0.0063084871508181095, 0.02481692284345627, 0.019079288467764854, 0.005214032717049122, 0.013002715073525906, 0.022059248760342598, 0.004872986581176519, 0.010930899530649185, 0.0391177162528038, 0.00480531994253397, 0.005859974306076765, 0.008871643804013729, 0.004727629013359547, 0.008161906152963638, 0.005965116899460554, 0.008855951018631458, 0.008594823069870472, 0.009068753570318222, 0.006331776734441519, 0.015348583459854126, 0.03960682451725006, 0.017449310049414635, 0.00878522451967001, 0.003098608460277319, 0.0157772246748209, 0.005100222770124674, 0.012622563168406487, 0.0063313753344118595, 0.030217325314879417, 0.013076139613986015, 0.006752963177859783, 0.008179759606719017, 0.004201702773571014, 0.006614595651626587, 0.018087206408381462, 0.010369800962507725, 0.008499695919454098, 0.015746651217341423, 0.02766180969774723, 0.011534102261066437, 0.016470741480588913, 0.005347998347133398, 0.010266348719596863, 0.03776094689965248, 0.02253921888768673, 0.0065194652415812016, 0.03657319024205208, 0.007733463309705257, 0.03088395670056343, 0.0042597330175340176, 0.004797681234776974, 0.05085315555334091, 0.08110080659389496, 0.03178226575255394, 0.07455640286207199], [0.021253405138850212, 0.007423452101647854, 0.012343655340373516, 0.01458623819053173, 0.03346366435289383, 0.006598835811018944, 0.03346320614218712, 0.022195395082235336, 0.005627488251775503, 0.015622330829501152, 0.02695966325700283, 0.007420658599585295, 0.012543529272079468, 0.04259425029158592, 0.004346439149230719, 0.004440830554813147, 0.010128088295459747, 0.0030758751090615988, 0.009829380549490452, 0.006744575221091509, 0.010834154672920704, 0.008442206308245659, 0.009559564292430878, 0.007541922852396965, 0.012446260079741478, 0.01787923090159893, 0.005677969194948673, 0.011616440489888191, 0.003293650457635522, 0.01936577446758747, 0.007329417858272791, 0.02818182483315468, 0.007822960615158081, 0.06313885003328323, 0.013711820356547832, 0.0077721131965518, 0.009499235078692436, 0.006077896803617477, 0.007759453263133764, 0.021490534767508507, 0.016353748738765717, 0.013778081163764, 0.030424930155277252, 0.0368390753865242, 0.009471669793128967, 0.019674023613333702, 0.005718025378882885, 0.013162900693714619, 0.040188778191804886, 0.01801380142569542, 0.006536012515425682, 0.03639065474271774, 0.006331616546958685, 0.02361389622092247, 0.0027799189556390047, 0.004186367616057396, 0.03118188865482807, 0.05050234496593475, 0.010657506063580513, 0.010378006845712662, 0.033714547753334045], [0.022612985223531723, 0.008581487461924553, 0.014957294799387455, 0.01877705194056034, 0.029775090515613556, 0.007040796801447868, 0.03942827135324478, 0.023050649091601372, 0.005438539199531078, 0.018016640096902847, 0.033204298466444016, 0.006733025889843702, 0.01588066853582859, 0.06694970279932022, 0.004581390414386988, 0.003880048170685768, 0.012556459754705429, 0.007403104100376368, 0.009995318949222565, 0.007175436709076166, 0.013234613463282585, 0.008807661011815071, 0.00784585252404213, 0.006126695778220892, 0.012549757026135921, 0.01900072954595089, 0.00601549819111824, 0.011146504431962967, 0.0038889977149665356, 0.01983528397977352, 0.0068621025420725346, 0.021854398772120476, 0.009126713499426842, 0.060260795056819916, 0.013785392045974731, 0.006978463847190142, 0.008646710775792599, 0.005344517529010773, 0.007033228408545256, 0.019927382469177246, 0.012967050075531006, 0.00999829825013876, 0.02448352426290512, 0.028524914756417274, 0.009736192412674427, 0.013909964822232723, 0.004363800399005413, 0.009047942236065865, 0.024072695523500443, 0.013115198351442814, 0.004176322370767593, 0.027989206835627556, 0.0069837793707847595, 0.026109714061021805, 0.0021705711260437965, 0.004769116640090942, 0.027468770742416382, 0.044022317975759506, 0.010589424520730972, 0.011225324124097824, 0.015706820413470268, 0.04425950348377228], [0.01895136572420597, 0.008268921636044979, 0.016607927158474922, 0.01695920340716839, 0.030994947999715805, 0.0068772416561841965, 0.03335089981555939, 0.021679051220417023, 0.005499332677572966, 0.014444910921156406, 0.021799083799123764, 0.0062435343861579895, 0.011513642966747284, 0.051342882215976715, 0.003836582414805889, 0.003928754013031721, 0.00980050303041935, 0.006267700344324112, 0.009246188215911388, 0.006059302948415279, 0.010903836227953434, 0.006927368231117725, 0.008913237601518631, 0.005981985479593277, 0.012558972463011742, 0.01921357959508896, 0.005835913587361574, 0.011833800934255123, 0.011429227888584137, 0.03478739783167839, 0.00716960895806551, 0.018286366015672684, 0.01196175254881382, 0.06014878302812576, 0.012134759686887264, 0.005975992884486914, 0.007912267930805683, 0.004073326475918293, 0.006199325434863567, 0.0182226300239563, 0.012589985504746437, 0.007051466498523951, 0.018396837636828423, 0.027872635051608086, 0.00648586917668581, 0.013424810022115707, 0.003960318863391876, 0.00859866850078106, 0.025369534268975258, 0.016843702644109726, 0.004851765930652618, 0.026780210435390472, 0.009593366645276546, 0.03742297366261482, 0.0022638000082224607, 0.0048475367948412895, 0.03279094770550728, 0.06348242610692978, 0.010257062502205372, 0.010602387599647045, 0.01764221303164959, 0.029719898477196693, 0.025009432807564735], [0.012835480272769928, 0.005583026446402073, 0.013907556422054768, 0.015350256115198135, 0.01790931634604931, 0.005332148168236017, 0.021461989730596542, 0.017678460106253624, 0.004271109122782946, 0.01296936348080635, 0.021129652857780457, 0.004524333402514458, 0.015036053955554962, 0.041854873299598694, 0.00590661121532321, 0.003608827944844961, 0.012750713154673576, 0.004282175563275814, 0.008130340836942196, 0.006444293074309826, 0.039992962032556534, 0.006980393081903458, 0.00636336300522089, 0.004712251480668783, 0.012648380361497402, 0.015735307708382607, 0.005592619068920612, 0.007580758072435856, 0.004408620297908783, 0.015638427808880806, 0.004490064922720194, 0.012032190337777138, 0.00557285500690341, 0.0373808816075325, 0.013699165545403957, 0.006307731848210096, 0.00629659928381443, 0.0036869077011942863, 0.005640121642500162, 0.019035011529922485, 0.009094050154089928, 0.009082090109586716, 0.012127266265451908, 0.025783738121390343, 0.004990020766854286, 0.011262068524956703, 0.003446988295763731, 0.00860507320612669, 0.03755722567439079, 0.02046102285385132, 0.004557227250188589, 0.04220261052250862, 0.013289214111864567, 0.038276225328445435, 0.003826298052445054, 0.004990527871996164, 0.04238737374544144, 0.054965727031230927, 0.010717217810451984, 0.012119658291339874, 0.016531044617295265, 0.018060561269521713, 0.03377899155020714, 0.07712657749652863], [0.017296848818659782, 0.006146437954157591, 0.013050178065896034, 0.013666006736457348, 0.01653299666941166, 0.005284830927848816, 0.02342263050377369, 0.01569521799683571, 0.0036601140163838863, 0.009921815246343613, 0.017543651163578033, 0.004341830965131521, 0.011513384990394115, 0.029814239591360092, 0.0031907735392451286, 0.0029637031257152557, 0.008026789873838425, 0.0039010876789689064, 0.007115367334336042, 0.004610814619809389, 0.016098544001579285, 0.00635188352316618, 0.00561049859970808, 0.003349071368575096, 0.010101384483277798, 0.013606395572423935, 0.003980440087616444, 0.00876337569206953, 0.003099568886682391, 0.01199655793607235, 0.0036569819785654545, 0.01431623287498951, 0.005066505633294582, 0.027882415801286697, 0.012326476164162159, 0.005391959100961685, 0.0067866044119000435, 0.004214475862681866, 0.005955667234957218, 0.01777583546936512, 0.008092552423477173, 0.007947446778416634, 0.015460951253771782, 0.019414352253079414, 0.0034646850544959307, 0.007036643568426371, 0.0035674634855240583, 0.007841408252716064, 0.027342282235622406, 0.007301177363842726, 0.0031842589378356934, 0.016589853912591934, 0.010860814712941647, 0.03758639469742775, 0.002218665089458227, 0.004179026931524277, 0.02843567728996277, 0.04153607785701752, 0.009791309013962746, 0.01062584389001131, 0.012112746015191078, 0.02093954011797905, 0.01679139956831932, 0.04042533040046692, 0.23322442173957825], [0.018598774448037148, 0.00652120728045702, 0.018955271691083908, 0.016893571242690086, 0.023642655462026596, 0.005268499255180359, 0.028537709265947342, 0.02034199796617031, 0.0044367569498717785, 0.01292630098760128, 0.02030961774289608, 0.0044418624602258205, 0.01197903323918581, 0.03267759457230568, 0.003745513968169689, 0.0030524933245033026, 0.009381940588355064, 0.0032371252309530973, 0.008736916817724705, 0.005845848936587572, 0.015912016853690147, 0.007337288465350866, 0.005672539584338665, 0.00476522883400321, 0.013553621247410774, 0.01632368192076683, 0.004479729570448399, 0.00849753525108099, 0.0028185658156871796, 0.01534856203943491, 0.003922628704458475, 0.015171578153967857, 0.004795267712324858, 0.034897346049547195, 0.011979004368185997, 0.0057693906128406525, 0.006372653879225254, 0.003522770944982767, 0.006297154352068901, 0.0155215784907341, 0.012010014615952969, 0.005689288955181837, 0.01532459445297718, 0.024973275139927864, 0.0030691141728311777, 0.007102825678884983, 0.002303273184224963, 0.006757811177521944, 0.024235015735030174, 0.007618576288223267, 0.006766908336430788, 0.01076811645179987, 0.00854476634413004, 0.027801165357232094, 0.0018274355679750443, 0.0036496936809271574, 0.022595083341002464, 0.043631669133901596, 0.007710618432611227, 0.009954371489584446, 0.01435413584113121, 0.014014523476362228, 0.011464281938970089, 0.017323557287454605, 0.13642720878124237, 0.09159382432699203], [0.03434240072965622, 0.007546942215412855, 0.01262525375932455, 0.016252918168902397, 0.01943065971136093, 0.00990856159478426, 0.027735935524106026, 0.017991697415709496, 0.005064910743385553, 0.011717415414750576, 0.02222997508943081, 0.006603062152862549, 0.011647496372461319, 0.04147420823574066, 0.00420520082116127, 0.0033061043359339237, 0.00840428564697504, 0.004123447462916374, 0.006662738509476185, 0.004977744072675705, 0.008326105773448944, 0.0062074135057628155, 0.007645832374691963, 0.004328862763941288, 0.011004374362528324, 0.02069890685379505, 0.008648925460875034, 0.0083983289077878, 0.003134029218927026, 0.013410710729658604, 0.004132104106247425, 0.014399122446775436, 0.006474950350821018, 0.03789469972252846, 0.01231063436716795, 0.007019704207777977, 0.01264934428036213, 0.008924518711864948, 0.00475325295701623, 0.014265312813222408, 0.00908783357590437, 0.00514258211478591, 0.012306513264775276, 0.018606949597597122, 0.004004263784736395, 0.00845225527882576, 0.0030571171082556248, 0.005867111962288618, 0.022412797436118126, 0.008147994056344032, 0.0028391515370458364, 0.016519559547305107, 0.008755836635828018, 0.02606263756752014, 0.002428078791126609, 0.004019671119749546, 0.02392592467367649, 0.037634026259183884, 0.009634766727685928, 0.010280200280249119, 0.013219551183283329, 0.022362494841217995, 0.011527587659657001, 0.026092855259776115, 0.07722707837820053, 0.0471862368285656, 0.0723208412528038], [0.022260548546910286, 0.007827301509678364, 0.016054008156061172, 0.02251431718468666, 0.024919068440794945, 0.008432946167886257, 0.041243281215429306, 0.01821194216609001, 0.004570990335196257, 0.021145178005099297, 0.035994429141283035, 0.006092384457588196, 0.021389396861195564, 0.08146101236343384, 0.003937745466828346, 0.00369447935372591, 0.02155596762895584, 0.003996813204139471, 0.006303656846284866, 0.004242696333676577, 0.015697326511144638, 0.0061682527884840965, 0.005011096131056547, 0.003403191454708576, 0.007988644763827324, 0.011214821599423885, 0.003161713480949402, 0.006709401495754719, 0.0026424797251820564, 0.010808693245053291, 0.0036973687820136547, 0.010656625963747501, 0.00441548740491271, 0.02873259410262108, 0.008273668587207794, 0.003804202424362302, 0.005169945769011974, 0.005301240831613541, 0.004103054292500019, 0.010758196003735065, 0.007981873117387295, 0.0042779636569321156, 0.009148800745606422, 0.015596581622958183, 0.0035910983569920063, 0.0062990509904921055, 0.0024203818757086992, 0.004885077942162752, 0.0215991772711277, 0.008731036446988583, 0.003824693849310279, 0.0206054225564003, 0.009703862480819225, 0.03652593120932579, 0.0024792728945612907, 0.003675516229122877, 0.038111936300992966, 0.035174425691366196, 0.006942955777049065, 0.008295618928968906, 0.012356607243418694, 0.018206050619482994, 0.013794799335300922, 0.03829961270093918, 0.059833817183971405, 0.023556193336844444, 0.03129233792424202, 0.01922375150024891], [0.012460466474294662, 0.005923563614487648, 0.0099134910851717, 0.013811648823320866, 0.016999375075101852, 0.006226206198334694, 0.04780562222003937, 0.026749510318040848, 0.0038752481341362, 0.013204637914896011, 0.027692170813679695, 0.005729828495532274, 0.011784560978412628, 0.04404868185520172, 0.003427949734032154, 0.0030529904179275036, 0.008908616378903389, 0.002915774006396532, 0.006894622929394245, 0.004174915142357349, 0.00873450469225645, 0.005487669259309769, 0.005306388717144728, 0.0030241229105740786, 0.007527521811425686, 0.010668760165572166, 0.003629630897194147, 0.007069790735840797, 0.0028563914820551872, 0.011868217028677464, 0.003643444273620844, 0.00951563473790884, 0.0042749326676130295, 0.02192341908812523, 0.008545957505702972, 0.004106726963073015, 0.005097523797303438, 0.004084778483957052, 0.005737014580518007, 0.013218753971159458, 0.007764376234263182, 0.005457489285618067, 0.011922544799745083, 0.018171876668930054, 0.0038008992560207844, 0.008195038884878159, 0.0028012164402753115, 0.0043671405874192715, 0.023646196350455284, 0.010953476652503014, 0.003031786996871233, 0.02137269824743271, 0.0107041010633111, 0.04502250626683235, 0.00239697122015059, 0.005145795177668333, 0.030968843027949333, 0.04488557577133179, 0.007957383058965206, 0.008325427770614624, 0.010251530446112156, 0.016853220760822296, 0.018661225214600563, 0.033806391060352325, 0.0469420924782753, 0.018598409369587898, 0.032954033464193344, 0.010291291400790215, 0.11282940208911896], [0.01570301689207554, 0.004536045249551535, 0.008458666503429413, 0.010786565952003002, 0.01423121802508831, 0.004571377765387297, 0.0314352884888649, 0.019694145768880844, 0.0035300489980727434, 0.010167817585170269, 0.016662653535604477, 0.004707202780991793, 0.008690256625413895, 0.0287831611931324, 0.0033740417566150427, 0.0029134114738553762, 0.00777049595490098, 0.003336431225761771, 0.008638715371489525, 0.004779792856425047, 0.008038888685405254, 0.009764275513589382, 0.006251155398786068, 0.0038781713228672743, 0.008634593337774277, 0.012385590001940727, 0.003818944562226534, 0.00696566142141819, 0.0029796049930155277, 0.010537314228713512, 0.0038395279552787542, 0.011967258527874947, 0.0055381134152412415, 0.02151205949485302, 0.011540571227669716, 0.006344438996165991, 0.005954327527433634, 0.0040033902041614056, 0.005273581016808748, 0.015147756785154343, 0.00993005558848381, 0.008649664930999279, 0.014407931827008724, 0.02406340278685093, 0.006063639186322689, 0.01803925260901451, 0.006142819300293922, 0.012106540612876415, 0.022470751777291298, 0.010915970429778099, 0.0037789135240018368, 0.026470400393009186, 0.010615076869726181, 0.035489778965711594, 0.0023900731466710567, 0.004049124661833048, 0.02521912381052971, 0.045000068843364716, 0.012854422442615032, 0.012222576886415482, 0.012691572308540344, 0.020723454654216766, 0.011135205626487732, 0.020811714231967926, 0.04152083769440651, 0.018165668472647667, 0.018503013998270035, 0.006500758696347475, 0.047411151230335236, 0.11451146006584167]]})\n",
               "\n",
               "             }, function (err) {\n",
               "                console.log(err);\n",
@@ -2566,7 +4839,7 @@
       "source": [
         "lm2 = ecco.from_pretrained('HooshvareLab/gpt2-fa', activations=True)"
       ],
-      "execution_count": 145,
+      "execution_count": 12,
       "outputs": []
     },
     {
@@ -2574,10 +4847,10 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 337
+          "height": 422
         },
         "id": "6doYhGw12w_m",
-        "outputId": "ebbe1dca-a000-4cd0-f64a-b73e926c0cff"
+        "outputId": "1df5f65b-d85b-4523-f72c-b7db7e9c74a7"
       },
       "source": [
         "text = \"\"\"\n",
@@ -2592,7 +4865,7 @@
         "\n",
         "output = lm2.generate(text, generate=1, do_sample=True)"
       ],
-      "execution_count": 157,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2687,9 +4960,9 @@
               "\n",
               "\n",
               "         requirejs( ['basic', 'ecco'], function(basic, ecco){\n",
-              "            basic.init('viz_995696')\n",
+              "            basic.init('viz_249698')\n",
               "\n",
-              "            window.ecco['viz_995696'] = ecco.renderOutputSequence('viz_995696', {'tokens': [{'token': 'هر', 'position': 0, 'token_id': 458, 'type': 'input'}, {'token': ' سال', 'position': 1, 'token_id': 415, 'type': 'input'}, {'token': ' ده', 'position': 2, 'token_id': 546, 'type': 'input'}, {'token': '\\u200c', 'position': 3, 'token_id': 285, 'type': 'input'}, {'token': 'ها', 'position': 4, 'token_id': 350, 'type': 'input'}, {'token': ' هزار', 'position': 5, 'token_id': 841, 'type': 'input'}, {'token': ' مقاله', 'position': 6, 'token_id': 1895, 'type': 'input'}, {'token': ' و', 'position': 7, 'token_id': 293, 'type': 'input'}, {'token': ' گزارش', 'position': 8, 'token_id': 893, 'type': 'input'}, {'token': ' راجع', 'position': 9, 'token_id': 5945, 'type': 'input'}, {'token': ' به', 'position': 10, 'token_id': 303, 'type': 'input'}, {'token': ' هوش', 'position': 11, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 12, 'token_id': 2734, 'type': 'input'}, {'token': ' منتشر', 'position': 13, 'token_id': 1099, 'type': 'input'}, {'token': ' می', 'position': 14, 'token_id': 310, 'type': 'input'}, {'token': '\\u200c', 'position': 15, 'token_id': 285, 'type': 'input'}, {'token': 'شود', 'position': 16, 'token_id': 431, 'type': 'input'}, {'token': '،', 'position': 17, 'token_id': 305, 'type': 'input'}, {'token': ' اما', 'position': 18, 'token_id': 492, 'type': 'input'}, {'token': ' اندکی', 'position': 19, 'token_id': 4111, 'type': 'input'}, {'token': ' زمان', 'position': 20, 'token_id': 701, 'type': 'input'}, {'token': ' می', 'position': 21, 'token_id': 310, 'type': 'input'}, {'token': ' برد', 'position': 22, 'token_id': 1981, 'type': 'input'}, {'token': ' تا', 'position': 23, 'token_id': 399, 'type': 'input'}, {'token': ' پتانسیل', 'position': 24, 'token_id': 6111, 'type': 'input'}, {'token': '\\u200c', 'position': 25, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 26, 'token_id': 325, 'type': 'input'}, {'token': ' مطرح', 'position': 27, 'token_id': 2031, 'type': 'input'}, {'token': ' شده', 'position': 28, 'token_id': 401, 'type': 'input'}, {'token': ' در', 'position': 29, 'token_id': 298, 'type': 'input'}, {'token': ' هرکدام', 'position': 30, 'token_id': 6242, 'type': 'input'}, {'token': ' از', 'position': 31, 'token_id': 312, 'type': 'input'}, {'token': ' این', 'position': 32, 'token_id': 326, 'type': 'input'}, {'token': ' مقالات', 'position': 33, 'token_id': 5320, 'type': 'input'}, {'token': ' تأثیری', 'position': 34, 'token_id': 11760, 'type': 'input'}, {'token': ' واضح', 'position': 35, 'token_id': 5272, 'type': 'input'}, {'token': ' و', 'position': 36, 'token_id': 293, 'type': 'input'}, {'token': ' محسوس', 'position': 37, 'token_id': 12950, 'type': 'input'}, {'token': ' بر', 'position': 38, 'token_id': 327, 'type': 'input'}, {'token': ' دنیای', 'position': 39, 'token_id': 2112, 'type': 'input'}, {'token': ' واقعی', 'position': 40, 'token_id': 2200, 'type': 'input'}, {'token': ' بگذارند', 'position': 41, 'token_id': 6406, 'type': 'input'}, {'token': '.', 'position': 42, 'token_id': 24, 'type': 'input'}, {'token': ' در', 'position': 43, 'token_id': 298, 'type': 'input'}, {'token': ' این', 'position': 44, 'token_id': 326, 'type': 'input'}, {'token': ' بین', 'position': 45, 'token_id': 619, 'type': 'input'}, {'token': '،', 'position': 46, 'token_id': 305, 'type': 'input'}, {'token': ' بزرگترین', 'position': 47, 'token_id': 3070, 'type': 'input'}, {'token': ' سرمایه', 'position': 48, 'token_id': 1266, 'type': 'input'}, {'token': '\\u200c', 'position': 49, 'token_id': 285, 'type': 'input'}, {'token': 'گذاران', 'position': 50, 'token_id': 4830, 'type': 'input'}, {'token': ' روی', 'position': 51, 'token_id': 539, 'type': 'input'}, {'token': ' هوش', 'position': 52, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 53, 'token_id': 2734, 'type': 'input'}, {'token': ' یعنی', 'position': 54, 'token_id': 1247, 'type': 'input'}, {'token': ' امثال', 'position': 55, 'token_id': 13505, 'type': 'input'}, {'token': ' آلفابت', 'position': 56, 'token_id': 14405, 'type': 'input'}, {'token': '،', 'position': 57, 'token_id': 305, 'type': 'input'}, {'token': ' اپل', 'position': 58, 'token_id': 1190, 'type': 'input'}, {'token': '،', 'position': 59, 'token_id': 305, 'type': 'input'}, {'token': ' فیسبوک', 'position': 60, 'token_id': 3942, 'type': 'input'}, {'token': '،', 'position': 61, 'token_id': 305, 'type': 'input'}, {'token': ' باید', 'position': 62, 'token_id': 544, 'type': 'input'}, {'token': 'وس', 'position': 63, 'token_id': 612, 'type': 'input'}, {'token': ' و', 'position': 64, 'token_id': 293, 'type': 'input'}, {'token': ' دیگر', 'position': 65, 'token_id': 530, 'type': 'input'}, {'token': ' اسب', 'position': 66, 'token_id': 2953, 'type': 'input'}, {'token': '\\u200c', 'position': 67, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 68, 'token_id': 325, 'type': 'input'}, {'token': ' تک', 'position': 69, 'token_id': 1396, 'type': 'input'}, {'token': '\\u200c', 'position': 70, 'token_id': 285, 'type': 'input'}, {'token': 'شاخ', 'position': 71, 'token_id': 12504, 'type': 'input'}, {'token': ' دنیای', 'position': 72, 'token_id': 2112, 'type': 'input'}, {'token': ' تکنولوژی', 'position': 73, 'token_id': 2061, 'type': 'input'}, {'token': '،', 'position': 74, 'token_id': 305, 'type': 'input'}, {'token': ' بخش', 'position': 75, 'token_id': 710, 'type': 'input'}, {'token': ' اعظمی', 'position': 76, 'token_id': 15349, 'type': 'input'}, {'token': ' از', 'position': 77, 'token_id': 312, 'type': 'input'}, {'token': ' دستاوردهای', 'position': 78, 'token_id': 7442, 'type': 'input'}, {'token': ' تکنولوژیک', 'position': 79, 'token_id': 17304, 'type': 'input'}, {'token': ' خود', 'position': 80, 'token_id': 377, 'type': 'input'}, {'token': ' را', 'position': 81, 'token_id': 330, 'type': 'input'}, {'token': ' پشت', 'position': 82, 'token_id': 1059, 'type': 'input'}, {'token': ' درهای', 'position': 83, 'token_id': 10399, 'type': 'input'}, {'token': ' بسته', 'position': 84, 'token_id': 1746, 'type': 'input'}, {'token': ' پنهان', 'position': 85, 'token_id': 4811, 'type': 'input'}, {'token': ' می', 'position': 86, 'token_id': 310, 'type': 'input'}, {'token': '\\u200c', 'position': 87, 'token_id': 285, 'type': 'input'}, {'token': 'کنند', 'position': 88, 'token_id': 606, 'type': 'input'}, {'token': '.', 'position': 89, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 90, 'token_id': 231, 'type': 'input'}, {'token': ' اگر', 'position': 91, 'token_id': 574, 'type': 'input'}, {'token': ' بخواهیم', 'position': 92, 'token_id': 6385, 'type': 'input'}, {'token': ' واضح', 'position': 93, 'token_id': 5272, 'type': 'input'}, {'token': '\\u200c', 'position': 94, 'token_id': 285, 'type': 'input'}, {'token': 'تر', 'position': 95, 'token_id': 344, 'type': 'input'}, {'token': ' بگوییم', 'position': 96, 'token_id': 4676, 'type': 'input'}, {'token': '،', 'position': 97, 'token_id': 305, 'type': 'input'}, {'token': ' وقتی', 'position': 98, 'token_id': 1277, 'type': 'input'}, {'token': ' صحبت', 'position': 99, 'token_id': 1868, 'type': 'input'}, {'token': ' از', 'position': 100, 'token_id': 312, 'type': 'input'}, {'token': ' هوش', 'position': 101, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 102, 'token_id': 2734, 'type': 'input'}, {'token': ' باشد', 'position': 103, 'token_id': 577, 'type': 'input'}, {'token': '،', 'position': 104, 'token_id': 305, 'type': 'input'}, {'token': ' لیست', 'position': 105, 'token_id': 2740, 'type': 'input'}, {'token': ' کردن', 'position': 106, 'token_id': 714, 'type': 'input'}, {'token': ' مهم', 'position': 107, 'token_id': 871, 'type': 'input'}, {'token': '\\u200c', 'position': 108, 'token_id': 285, 'type': 'input'}, {'token': 'ترین', 'position': 109, 'token_id': 496, 'type': 'input'}, {'token': ' دستاوردها', 'position': 110, 'token_id': 20176, 'type': 'input'}, {'token': ' در', 'position': 111, 'token_id': 298, 'type': 'input'}, {'token': ' بازه', 'position': 112, 'token_id': 4051, 'type': 'input'}, {'token': '\\u200c', 'position': 113, 'token_id': 285, 'type': 'input'}, {'token': 'ای', 'position': 114, 'token_id': 289, 'type': 'input'}, {'token': ' یک', 'position': 115, 'token_id': 367, 'type': 'input'}, {'token': '\\u200c', 'position': 116, 'token_id': 285, 'type': 'input'}, {'token': 'ساله', 'position': 117, 'token_id': 6857, 'type': 'input'}, {'token': ' کاری', 'position': 118, 'token_id': 1379, 'type': 'input'}, {'token': ' آسان', 'position': 119, 'token_id': 3109, 'type': 'input'}, {'token': ' به', 'position': 120, 'token_id': 303, 'type': 'input'}, {'token': ' حساب', 'position': 121, 'token_id': 1650, 'type': 'input'}, {'token': ' نمی', 'position': 122, 'token_id': 624, 'type': 'input'}, {'token': '\\u200c', 'position': 123, 'token_id': 285, 'type': 'input'}, {'token': 'آید', 'position': 124, 'token_id': 1721, 'type': 'input'}, {'token': '؛', 'position': 125, 'token_id': 556, 'type': 'input'}, {'token': ' حداقل', 'position': 126, 'token_id': 2235, 'type': 'input'}, {'token': ' نه', 'position': 127, 'token_id': 995, 'type': 'input'}, {'token': ' به', 'position': 128, 'token_id': 303, 'type': 'input'}, {'token': ' آسانی', 'position': 129, 'token_id': 7654, 'type': 'input'}, {'token': ' لیست', 'position': 130, 'token_id': 2740, 'type': 'input'}, {'token': ' کردن', 'position': 131, 'token_id': 714, 'type': 'input'}, {'token': ' بهترین', 'position': 132, 'token_id': 1142, 'type': 'input'}, {'token': ' موبایل', 'position': 133, 'token_id': 1532, 'type': 'input'}, {'token': '\\u200c', 'position': 134, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 135, 'token_id': 325, 'type': 'input'}, {'token': ' پرچمدار', 'position': 136, 'token_id': 4810, 'type': 'input'}, {'token': ' یا', 'position': 137, 'token_id': 421, 'type': 'input'}, {'token': ' بهترین', 'position': 138, 'token_id': 1142, 'type': 'input'}, {'token': ' ویژگی', 'position': 139, 'token_id': 1413, 'type': 'input'}, {'token': '\\u200c', 'position': 140, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 141, 'token_id': 325, 'type': 'input'}, {'token': ' اضافه', 'position': 142, 'token_id': 1469, 'type': 'input'}, {'token': ' شده', 'position': 143, 'token_id': 401, 'type': 'input'}, {'token': ' به', 'position': 144, 'token_id': 303, 'type': 'input'}, {'token': ' تازه', 'position': 145, 'token_id': 1903, 'type': 'input'}, {'token': '\\u200c', 'position': 146, 'token_id': 285, 'type': 'input'}, {'token': 'ترین', 'position': 147, 'token_id': 496, 'type': 'input'}, {'token': ' ورژن', 'position': 148, 'token_id': 10005, 'type': 'input'}, {'token': ' از', 'position': 149, 'token_id': 312, 'type': 'input'}, {'token': ' iOS', 'position': 150, 'token_id': 3658, 'type': 'input'}, {'token': '.', 'position': 151, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 152, 'token_id': 231, 'type': 'input'}, {'token': ' اما', 'position': 153, 'token_id': 492, 'type': 'input'}, {'token': ' هرطور', 'position': 154, 'token_id': 39899, 'type': 'input'}, {'token': ' که', 'position': 155, 'token_id': 323, 'type': 'input'}, {'token': ' به', 'position': 156, 'token_id': 303, 'type': 'input'}, {'token': ' موضوع', 'position': 157, 'token_id': 964, 'type': 'input'}, {'token': ' نگاه', 'position': 158, 'token_id': 1624, 'type': 'input'}, {'token': ' کنیم', 'position': 159, 'token_id': 1085, 'type': 'input'}, {'token': '،', 'position': 160, 'token_id': 305, 'type': 'input'}, {'token': ' هوش', 'position': 161, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 162, 'token_id': 2734, 'type': 'input'}, {'token': ' بدون', 'position': 163, 'token_id': 1042, 'type': 'input'}, {'token': ' تردید', 'position': 164, 'token_id': 6746, 'type': 'input'}, {'token': ' نقشی', 'position': 165, 'token_id': 6806, 'type': 'input'}, {'token': ' بزرگ', 'position': 166, 'token_id': 745, 'type': 'input'}, {'token': ' در', 'position': 167, 'token_id': 298, 'type': 'input'}, {'token': ' سال', 'position': 168, 'token_id': 415, 'type': 'input'}, {'token': ' ۲۰۲۰', 'position': 169, 'token_id': 3668, 'type': 'input'}, {'token': ' میلادی', 'position': 170, 'token_id': 1547, 'type': 'input'}, {'token': ' ایفا', 'position': 171, 'token_id': 4912, 'type': 'input'}, {'token': ' کرده', 'position': 172, 'token_id': 501, 'type': 'input'}, {'token': ' است', 'position': 173, 'token_id': 329, 'type': 'input'}, {'token': '.', 'position': 174, 'token_id': 24, 'type': 'input'}, {'token': ' بنابراین', 'position': 175, 'token_id': 1504, 'type': 'input'}, {'token': ' بیایید', 'position': 176, 'token_id': 7496, 'type': 'input'}, {'token': ' به', 'position': 177, 'token_id': 303, 'type': 'input'}, {'token': ' مرور', 'position': 178, 'token_id': 2550, 'type': 'input'}, {'token': ' شش', 'position': 179, 'token_id': 2606, 'type': 'input'}, {'token': ' دستاورد', 'position': 180, 'token_id': 8149, 'type': 'input'}, {'token': ' بزرگ', 'position': 181, 'token_id': 745, 'type': 'input'}, {'token': ' هوش', 'position': 182, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 183, 'token_id': 2734, 'type': 'input'}, {'token': ' در', 'position': 184, 'token_id': 298, 'type': 'input'}, {'token': ' سالی', 'position': 185, 'token_id': 4029, 'type': 'input'}, {'token': ' که', 'position': 186, 'token_id': 323, 'type': 'input'}, {'token': ' اکنون', 'position': 187, 'token_id': 1801, 'type': 'input'}, {'token': ' به', 'position': 188, 'token_id': 303, 'type': 'input'}, {'token': ' روزهای', 'position': 189, 'token_id': 2897, 'type': 'input'}, {'token': ' آخرش', 'position': 190, 'token_id': 16847, 'type': 'input'}, {'token': ' نزدیک', 'position': 191, 'token_id': 1460, 'type': 'input'}, {'token': ' شده', 'position': 192, 'token_id': 401, 'type': 'input'}, {'token': ' بپردازیم', 'position': 193, 'token_id': 7984, 'type': 'input'}, {'token': '.', 'position': 194, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 195, 'token_id': 231, 'type': 'input'}, {'token': ' در', 'position': 196, 'token_id': 298, 'type': 'input'}, {'token': ' یک', 'position': 197, 'token_id': 367, 'type': 'input'}, {'token': ' سال', 'position': 198, 'token_id': 415, 'type': 'input'}, {'token': ' معمولی', 'position': 199, 'token_id': 3350, 'type': 'input'}, {'token': '،', 'position': 200, 'token_id': 305, 'type': 'input'}, {'token': ' ابزاری', 'position': 201, 'token_id': 6048, 'type': 'input'}, {'token': ' که', 'position': 202, 'token_id': 323, 'type': 'input'}, {'token': ' کارش', 'position': 203, 'token_id': 6853, 'type': 'input'}, {'token': ' تولید', 'position': 204, 'token_id': 667, 'type': 'input'}, {'token': ' متن', 'position': 205, 'token_id': 1555, 'type': 'input'}, {'token': ' است', 'position': 206, 'token_id': 329, 'type': 'input'}, {'token': ' به', 'position': 207, 'token_id': 303, 'type': 'input'}, {'token': ' هیچ', 'position': 208, 'token_id': 917, 'type': 'input'}, {'token': '\\u200c', 'position': 209, 'token_id': 285, 'type': 'input'}, {'token': 'وجه', 'position': 210, 'token_id': 8362, 'type': 'input'}, {'token': ' جزء', 'position': 211, 'token_id': 5953, 'type': 'input'}, {'token': ' هیجان', 'position': 212, 'token_id': 3814, 'type': 'input'}, {'token': '\\u200c', 'position': 213, 'token_id': 285, 'type': 'input'}, {'token': 'انگیزترین', 'position': 214, 'token_id': 20502, 'type': 'input'}, {'token': ' دستاوردهای', 'position': 215, 'token_id': 7442, 'type': 'input'}, {'token': ' حوزه', 'position': 216, 'token_id': 1403, 'type': 'input'}, {'token': ' هوش', 'position': 217, 'token_id': 976, 'type': 'input'}]})\n",
+              "            window.ecco['viz_249698'] = ecco.renderOutputSequence('viz_249698', {'tokens': [{'token': 'هر', 'position': 0, 'token_id': 458, 'type': 'input'}, {'token': ' سال', 'position': 1, 'token_id': 415, 'type': 'input'}, {'token': ' ده', 'position': 2, 'token_id': 546, 'type': 'input'}, {'token': '\\u200c', 'position': 3, 'token_id': 285, 'type': 'input'}, {'token': 'ها', 'position': 4, 'token_id': 350, 'type': 'input'}, {'token': ' هزار', 'position': 5, 'token_id': 841, 'type': 'input'}, {'token': ' مقاله', 'position': 6, 'token_id': 1895, 'type': 'input'}, {'token': ' و', 'position': 7, 'token_id': 293, 'type': 'input'}, {'token': ' گزارش', 'position': 8, 'token_id': 893, 'type': 'input'}, {'token': ' راجع', 'position': 9, 'token_id': 5945, 'type': 'input'}, {'token': ' به', 'position': 10, 'token_id': 303, 'type': 'input'}, {'token': ' هوش', 'position': 11, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 12, 'token_id': 2734, 'type': 'input'}, {'token': ' منتشر', 'position': 13, 'token_id': 1099, 'type': 'input'}, {'token': ' می', 'position': 14, 'token_id': 310, 'type': 'input'}, {'token': '\\u200c', 'position': 15, 'token_id': 285, 'type': 'input'}, {'token': 'شود', 'position': 16, 'token_id': 431, 'type': 'input'}, {'token': '،', 'position': 17, 'token_id': 305, 'type': 'input'}, {'token': ' اما', 'position': 18, 'token_id': 492, 'type': 'input'}, {'token': ' اندکی', 'position': 19, 'token_id': 4111, 'type': 'input'}, {'token': ' زمان', 'position': 20, 'token_id': 701, 'type': 'input'}, {'token': ' می', 'position': 21, 'token_id': 310, 'type': 'input'}, {'token': ' برد', 'position': 22, 'token_id': 1981, 'type': 'input'}, {'token': ' تا', 'position': 23, 'token_id': 399, 'type': 'input'}, {'token': ' پتانسیل', 'position': 24, 'token_id': 6111, 'type': 'input'}, {'token': '\\u200c', 'position': 25, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 26, 'token_id': 325, 'type': 'input'}, {'token': ' مطرح', 'position': 27, 'token_id': 2031, 'type': 'input'}, {'token': ' شده', 'position': 28, 'token_id': 401, 'type': 'input'}, {'token': ' در', 'position': 29, 'token_id': 298, 'type': 'input'}, {'token': ' هرکدام', 'position': 30, 'token_id': 6242, 'type': 'input'}, {'token': ' از', 'position': 31, 'token_id': 312, 'type': 'input'}, {'token': ' این', 'position': 32, 'token_id': 326, 'type': 'input'}, {'token': ' مقالات', 'position': 33, 'token_id': 5320, 'type': 'input'}, {'token': ' تأثیری', 'position': 34, 'token_id': 11760, 'type': 'input'}, {'token': ' واضح', 'position': 35, 'token_id': 5272, 'type': 'input'}, {'token': ' و', 'position': 36, 'token_id': 293, 'type': 'input'}, {'token': ' محسوس', 'position': 37, 'token_id': 12950, 'type': 'input'}, {'token': ' بر', 'position': 38, 'token_id': 327, 'type': 'input'}, {'token': ' دنیای', 'position': 39, 'token_id': 2112, 'type': 'input'}, {'token': ' واقعی', 'position': 40, 'token_id': 2200, 'type': 'input'}, {'token': ' بگذارند', 'position': 41, 'token_id': 6406, 'type': 'input'}, {'token': '.', 'position': 42, 'token_id': 24, 'type': 'input'}, {'token': ' در', 'position': 43, 'token_id': 298, 'type': 'input'}, {'token': ' این', 'position': 44, 'token_id': 326, 'type': 'input'}, {'token': ' بین', 'position': 45, 'token_id': 619, 'type': 'input'}, {'token': '،', 'position': 46, 'token_id': 305, 'type': 'input'}, {'token': ' بزرگترین', 'position': 47, 'token_id': 3070, 'type': 'input'}, {'token': ' سرمایه', 'position': 48, 'token_id': 1266, 'type': 'input'}, {'token': '\\u200c', 'position': 49, 'token_id': 285, 'type': 'input'}, {'token': 'گذاران', 'position': 50, 'token_id': 4830, 'type': 'input'}, {'token': ' روی', 'position': 51, 'token_id': 539, 'type': 'input'}, {'token': ' هوش', 'position': 52, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 53, 'token_id': 2734, 'type': 'input'}, {'token': ' یعنی', 'position': 54, 'token_id': 1247, 'type': 'input'}, {'token': ' امثال', 'position': 55, 'token_id': 13505, 'type': 'input'}, {'token': ' آلفابت', 'position': 56, 'token_id': 14405, 'type': 'input'}, {'token': '،', 'position': 57, 'token_id': 305, 'type': 'input'}, {'token': ' اپل', 'position': 58, 'token_id': 1190, 'type': 'input'}, {'token': '،', 'position': 59, 'token_id': 305, 'type': 'input'}, {'token': ' فیسبوک', 'position': 60, 'token_id': 3942, 'type': 'input'}, {'token': '،', 'position': 61, 'token_id': 305, 'type': 'input'}, {'token': ' باید', 'position': 62, 'token_id': 544, 'type': 'input'}, {'token': 'وس', 'position': 63, 'token_id': 612, 'type': 'input'}, {'token': ' و', 'position': 64, 'token_id': 293, 'type': 'input'}, {'token': ' دیگر', 'position': 65, 'token_id': 530, 'type': 'input'}, {'token': ' اسب', 'position': 66, 'token_id': 2953, 'type': 'input'}, {'token': '\\u200c', 'position': 67, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 68, 'token_id': 325, 'type': 'input'}, {'token': ' تک', 'position': 69, 'token_id': 1396, 'type': 'input'}, {'token': '\\u200c', 'position': 70, 'token_id': 285, 'type': 'input'}, {'token': 'شاخ', 'position': 71, 'token_id': 12504, 'type': 'input'}, {'token': ' دنیای', 'position': 72, 'token_id': 2112, 'type': 'input'}, {'token': ' تکنولوژی', 'position': 73, 'token_id': 2061, 'type': 'input'}, {'token': '،', 'position': 74, 'token_id': 305, 'type': 'input'}, {'token': ' بخش', 'position': 75, 'token_id': 710, 'type': 'input'}, {'token': ' اعظمی', 'position': 76, 'token_id': 15349, 'type': 'input'}, {'token': ' از', 'position': 77, 'token_id': 312, 'type': 'input'}, {'token': ' دستاوردهای', 'position': 78, 'token_id': 7442, 'type': 'input'}, {'token': ' تکنولوژیک', 'position': 79, 'token_id': 17304, 'type': 'input'}, {'token': ' خود', 'position': 80, 'token_id': 377, 'type': 'input'}, {'token': ' را', 'position': 81, 'token_id': 330, 'type': 'input'}, {'token': ' پشت', 'position': 82, 'token_id': 1059, 'type': 'input'}, {'token': ' درهای', 'position': 83, 'token_id': 10399, 'type': 'input'}, {'token': ' بسته', 'position': 84, 'token_id': 1746, 'type': 'input'}, {'token': ' پنهان', 'position': 85, 'token_id': 4811, 'type': 'input'}, {'token': ' می', 'position': 86, 'token_id': 310, 'type': 'input'}, {'token': '\\u200c', 'position': 87, 'token_id': 285, 'type': 'input'}, {'token': 'کنند', 'position': 88, 'token_id': 606, 'type': 'input'}, {'token': '.', 'position': 89, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 90, 'token_id': 231, 'type': 'input'}, {'token': ' اگر', 'position': 91, 'token_id': 574, 'type': 'input'}, {'token': ' بخواهیم', 'position': 92, 'token_id': 6385, 'type': 'input'}, {'token': ' واضح', 'position': 93, 'token_id': 5272, 'type': 'input'}, {'token': '\\u200c', 'position': 94, 'token_id': 285, 'type': 'input'}, {'token': 'تر', 'position': 95, 'token_id': 344, 'type': 'input'}, {'token': ' بگوییم', 'position': 96, 'token_id': 4676, 'type': 'input'}, {'token': '،', 'position': 97, 'token_id': 305, 'type': 'input'}, {'token': ' وقتی', 'position': 98, 'token_id': 1277, 'type': 'input'}, {'token': ' صحبت', 'position': 99, 'token_id': 1868, 'type': 'input'}, {'token': ' از', 'position': 100, 'token_id': 312, 'type': 'input'}, {'token': ' هوش', 'position': 101, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 102, 'token_id': 2734, 'type': 'input'}, {'token': ' باشد', 'position': 103, 'token_id': 577, 'type': 'input'}, {'token': '،', 'position': 104, 'token_id': 305, 'type': 'input'}, {'token': ' لیست', 'position': 105, 'token_id': 2740, 'type': 'input'}, {'token': ' کردن', 'position': 106, 'token_id': 714, 'type': 'input'}, {'token': ' مهم', 'position': 107, 'token_id': 871, 'type': 'input'}, {'token': '\\u200c', 'position': 108, 'token_id': 285, 'type': 'input'}, {'token': 'ترین', 'position': 109, 'token_id': 496, 'type': 'input'}, {'token': ' دستاوردها', 'position': 110, 'token_id': 20176, 'type': 'input'}, {'token': ' در', 'position': 111, 'token_id': 298, 'type': 'input'}, {'token': ' بازه', 'position': 112, 'token_id': 4051, 'type': 'input'}, {'token': '\\u200c', 'position': 113, 'token_id': 285, 'type': 'input'}, {'token': 'ای', 'position': 114, 'token_id': 289, 'type': 'input'}, {'token': ' یک', 'position': 115, 'token_id': 367, 'type': 'input'}, {'token': '\\u200c', 'position': 116, 'token_id': 285, 'type': 'input'}, {'token': 'ساله', 'position': 117, 'token_id': 6857, 'type': 'input'}, {'token': ' کاری', 'position': 118, 'token_id': 1379, 'type': 'input'}, {'token': ' آسان', 'position': 119, 'token_id': 3109, 'type': 'input'}, {'token': ' به', 'position': 120, 'token_id': 303, 'type': 'input'}, {'token': ' حساب', 'position': 121, 'token_id': 1650, 'type': 'input'}, {'token': ' نمی', 'position': 122, 'token_id': 624, 'type': 'input'}, {'token': '\\u200c', 'position': 123, 'token_id': 285, 'type': 'input'}, {'token': 'آید', 'position': 124, 'token_id': 1721, 'type': 'input'}, {'token': '؛', 'position': 125, 'token_id': 556, 'type': 'input'}, {'token': ' حداقل', 'position': 126, 'token_id': 2235, 'type': 'input'}, {'token': ' نه', 'position': 127, 'token_id': 995, 'type': 'input'}, {'token': ' به', 'position': 128, 'token_id': 303, 'type': 'input'}, {'token': ' آسانی', 'position': 129, 'token_id': 7654, 'type': 'input'}, {'token': ' لیست', 'position': 130, 'token_id': 2740, 'type': 'input'}, {'token': ' کردن', 'position': 131, 'token_id': 714, 'type': 'input'}, {'token': ' بهترین', 'position': 132, 'token_id': 1142, 'type': 'input'}, {'token': ' موبایل', 'position': 133, 'token_id': 1532, 'type': 'input'}, {'token': '\\u200c', 'position': 134, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 135, 'token_id': 325, 'type': 'input'}, {'token': ' پرچمدار', 'position': 136, 'token_id': 4810, 'type': 'input'}, {'token': ' یا', 'position': 137, 'token_id': 421, 'type': 'input'}, {'token': ' بهترین', 'position': 138, 'token_id': 1142, 'type': 'input'}, {'token': ' ویژگی', 'position': 139, 'token_id': 1413, 'type': 'input'}, {'token': '\\u200c', 'position': 140, 'token_id': 285, 'type': 'input'}, {'token': 'های', 'position': 141, 'token_id': 325, 'type': 'input'}, {'token': ' اضافه', 'position': 142, 'token_id': 1469, 'type': 'input'}, {'token': ' شده', 'position': 143, 'token_id': 401, 'type': 'input'}, {'token': ' به', 'position': 144, 'token_id': 303, 'type': 'input'}, {'token': ' تازه', 'position': 145, 'token_id': 1903, 'type': 'input'}, {'token': '\\u200c', 'position': 146, 'token_id': 285, 'type': 'input'}, {'token': 'ترین', 'position': 147, 'token_id': 496, 'type': 'input'}, {'token': ' ورژن', 'position': 148, 'token_id': 10005, 'type': 'input'}, {'token': ' از', 'position': 149, 'token_id': 312, 'type': 'input'}, {'token': ' iOS', 'position': 150, 'token_id': 3658, 'type': 'input'}, {'token': '.', 'position': 151, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 152, 'token_id': 231, 'type': 'input'}, {'token': ' اما', 'position': 153, 'token_id': 492, 'type': 'input'}, {'token': ' هرطور', 'position': 154, 'token_id': 39899, 'type': 'input'}, {'token': ' که', 'position': 155, 'token_id': 323, 'type': 'input'}, {'token': ' به', 'position': 156, 'token_id': 303, 'type': 'input'}, {'token': ' موضوع', 'position': 157, 'token_id': 964, 'type': 'input'}, {'token': ' نگاه', 'position': 158, 'token_id': 1624, 'type': 'input'}, {'token': ' کنیم', 'position': 159, 'token_id': 1085, 'type': 'input'}, {'token': '،', 'position': 160, 'token_id': 305, 'type': 'input'}, {'token': ' هوش', 'position': 161, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 162, 'token_id': 2734, 'type': 'input'}, {'token': ' بدون', 'position': 163, 'token_id': 1042, 'type': 'input'}, {'token': ' تردید', 'position': 164, 'token_id': 6746, 'type': 'input'}, {'token': ' نقشی', 'position': 165, 'token_id': 6806, 'type': 'input'}, {'token': ' بزرگ', 'position': 166, 'token_id': 745, 'type': 'input'}, {'token': ' در', 'position': 167, 'token_id': 298, 'type': 'input'}, {'token': ' سال', 'position': 168, 'token_id': 415, 'type': 'input'}, {'token': ' ۲۰۲۰', 'position': 169, 'token_id': 3668, 'type': 'input'}, {'token': ' میلادی', 'position': 170, 'token_id': 1547, 'type': 'input'}, {'token': ' ایفا', 'position': 171, 'token_id': 4912, 'type': 'input'}, {'token': ' کرده', 'position': 172, 'token_id': 501, 'type': 'input'}, {'token': ' است', 'position': 173, 'token_id': 329, 'type': 'input'}, {'token': '.', 'position': 174, 'token_id': 24, 'type': 'input'}, {'token': ' بنابراین', 'position': 175, 'token_id': 1504, 'type': 'input'}, {'token': ' بیایید', 'position': 176, 'token_id': 7496, 'type': 'input'}, {'token': ' به', 'position': 177, 'token_id': 303, 'type': 'input'}, {'token': ' مرور', 'position': 178, 'token_id': 2550, 'type': 'input'}, {'token': ' شش', 'position': 179, 'token_id': 2606, 'type': 'input'}, {'token': ' دستاورد', 'position': 180, 'token_id': 8149, 'type': 'input'}, {'token': ' بزرگ', 'position': 181, 'token_id': 745, 'type': 'input'}, {'token': ' هوش', 'position': 182, 'token_id': 976, 'type': 'input'}, {'token': ' مصنوعی', 'position': 183, 'token_id': 2734, 'type': 'input'}, {'token': ' در', 'position': 184, 'token_id': 298, 'type': 'input'}, {'token': ' سالی', 'position': 185, 'token_id': 4029, 'type': 'input'}, {'token': ' که', 'position': 186, 'token_id': 323, 'type': 'input'}, {'token': ' اکنون', 'position': 187, 'token_id': 1801, 'type': 'input'}, {'token': ' به', 'position': 188, 'token_id': 303, 'type': 'input'}, {'token': ' روزهای', 'position': 189, 'token_id': 2897, 'type': 'input'}, {'token': ' آخرش', 'position': 190, 'token_id': 16847, 'type': 'input'}, {'token': ' نزدیک', 'position': 191, 'token_id': 1460, 'type': 'input'}, {'token': ' شده', 'position': 192, 'token_id': 401, 'type': 'input'}, {'token': ' بپردازیم', 'position': 193, 'token_id': 7984, 'type': 'input'}, {'token': '.', 'position': 194, 'token_id': 24, 'type': 'input'}, {'token': ' ', 'position': 195, 'token_id': 231, 'type': 'input'}, {'token': ' در', 'position': 196, 'token_id': 298, 'type': 'input'}, {'token': ' یک', 'position': 197, 'token_id': 367, 'type': 'input'}, {'token': ' سال', 'position': 198, 'token_id': 415, 'type': 'input'}, {'token': ' معمولی', 'position': 199, 'token_id': 3350, 'type': 'input'}, {'token': '،', 'position': 200, 'token_id': 305, 'type': 'input'}, {'token': ' ابزاری', 'position': 201, 'token_id': 6048, 'type': 'input'}, {'token': ' که', 'position': 202, 'token_id': 323, 'type': 'input'}, {'token': ' کارش', 'position': 203, 'token_id': 6853, 'type': 'input'}, {'token': ' تولید', 'position': 204, 'token_id': 667, 'type': 'input'}, {'token': ' متن', 'position': 205, 'token_id': 1555, 'type': 'input'}, {'token': ' است', 'position': 206, 'token_id': 329, 'type': 'input'}, {'token': ' به', 'position': 207, 'token_id': 303, 'type': 'input'}, {'token': ' هیچ', 'position': 208, 'token_id': 917, 'type': 'input'}, {'token': '\\u200c', 'position': 209, 'token_id': 285, 'type': 'input'}, {'token': 'وجه', 'position': 210, 'token_id': 8362, 'type': 'input'}, {'token': ' جزء', 'position': 211, 'token_id': 5953, 'type': 'input'}, {'token': ' هیجان', 'position': 212, 'token_id': 3814, 'type': 'input'}, {'token': '\\u200c', 'position': 213, 'token_id': 285, 'type': 'input'}, {'token': 'انگیزترین', 'position': 214, 'token_id': 20502, 'type': 'input'}, {'token': ' دستاوردهای', 'position': 215, 'token_id': 7442, 'type': 'input'}, {'token': ' حوزه', 'position': 216, 'token_id': 1403, 'type': 'input'}, {'token': ' هوش', 'position': 217, 'token_id': 976, 'type': 'input'}]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })\n"
@@ -2710,9 +4983,9 @@
               "        // We don't really need these require scripts. But this is to avert\n",
               "        //this code from running before display_input_sequence which DOES require external files\n",
               "        requirejs(['basic', 'ecco'], function(basic, ecco){\n",
-              "                console.log('addToken viz_id', 'viz_995696');\n",
-              "                window.ecco['viz_995696'].addToken({\"token\": \" \\u0645\\u0635\\u0646\\u0648\\u0639\\u06cc\", \"token_id\": 2734, \"position\": 218, \"type\": \"output\"})\n",
-              "                window.ecco['viz_995696'].redraw()\n",
+              "                console.log('addToken viz_id', 'viz_249698');\n",
+              "                window.ecco['viz_249698'].addToken({\"token\": \" \\u0645\\u0635\\u0646\\u0648\\u0639\\u06cc\", \"token_id\": 2734, \"position\": 218, \"type\": \"output\"})\n",
+              "                window.ecco['viz_249698'].redraw()\n",
               "        })\n",
               "        "
             ],
@@ -2735,7 +5008,7 @@
         "# Factorize activations in all the layers\n",
         "nmf_1 = output.run_nmf(n_components=10) "
       ],
-      "execution_count": 158,
+      "execution_count": 14,
       "outputs": []
     },
     {
@@ -2743,15 +5016,15 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 364
+          "height": 285
         },
         "id": "s68k04Kh3mUL",
-        "outputId": "b45d9c3e-215b-4fb4-9ac4-1d1ce0d346e5"
+        "outputId": "876771bf-9ab2-42a6-def8-56a35a3f6fb4"
       },
       "source": [
         "nmf_1.explore()"
       ],
-      "execution_count": 159,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2846,7 +5119,7 @@
               "\n",
               "         requirejs(['basic', 'ecco'], function(basic, ecco){\n",
               "            const viz_id = basic.init()\n",
-              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[0.0, 0.0, 0.0, 0.0, 0.0389832928776741, 0.05167125537991524, 0.0, 0.25731295347213745, 0.0, 0.02109987661242485, 0.2076764553785324, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.001827308558858931, 0.0, 0.0, 0.0, 0.0, 0.06675779819488525, 0.14584611356258392, 0.029074711725115776, 0.08292340487241745, 0.012337341904640198, 0.0, 0.1741565465927124, 0.07173352688550949, 0.5770696401596069, 0.4868057370185852, 0.0, 0.0, 0.0, 0.022172661498188972, 0.0, 0.17552435398101807, 0.09056130051612854, 0.0, 0.0, 0.0, 0.06337012350559235, 0.18615403771400452, 0.042412228882312775, 0.0356333889067173, 0.5228452682495117, 0.0, 0.0, 0.0, 0.14349666237831116, 0.0, 0.0, 0.014645890332758427, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01825721748173237, 0.0, 0.0, 0.5055509209632874, 0.0019276444800198078, 0.0, 0.0, 0.05494506284594536, 0.0, 0.0, 0.024342525750398636, 0.0, 0.0024876787792891264, 0.1814815104007721, 0.1211712583899498, 0.2750230133533478, 0.0, 0.0, 0.0, 0.0298396535217762, 0.26215213537216187, 0.025175118818879128, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014392905868589878, 0.05880105122923851, 0.25375252962112427, 0.0, 0.0, 0.0, 0.0005583259626291692, 0.617974579334259, 0.7412024140357971, 0.35781317949295044, 0.13029927015304565, 0.9851645231246948, 0.0, 0.164781853556633, 0.15456701815128326, 0.008740951307117939, 0.027984226122498512, 0.05049549788236618, 0.0, 0.0, 0.023060470819473267, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09204355627298355, 0.05044650286436081, 0.051632922142744064, 0.06655896455049515, 0.18660935759544373, 0.4239736497402191, 0.6251664161682129, 0.9322993159294128, 0.00529787503182888, 0.0, 0.0, 0.0, 0.27514222264289856, 0.6725965738296509, 0.05490022525191307, 0.0, 0.023620693013072014, 0.0, 0.0, 0.19405782222747803, 0.16339769959449768, 0.023623649030923843, 0.6405476331710815, 0.14280594885349274, 0.2843170762062073, 0.0, 0.005417569074779749, 0.0, 0.04799319803714752, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011562916450202465, 0.0, 0.06935787945985794, 0.21317511796951294, 0.21642322838306427, 0.11297827214002609, 0.007603618316352367, 0.251479834318161, 0.051964182406663895, 0.0, 0.0, 0.004682713188230991, 0.003931994549930096, 0.022339507937431335, 0.0031286445446312428, 0.0, 0.0, 0.07534128427505493, 0.27130571007728577, 0.5416988134384155, 0.0, 0.0, 0.0, 0.0, 0.04214169457554817, 0.0, 0.0, 0.0, 0.02803497016429901, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011444286443293095, 0.0, 0.051300298422575, 0.14311583340168, 0.0, 0.0, 0.05934586375951767, 0.05233915522694588, 0.05185452476143837, 0.18290631473064423, 0.5269215703010559, 0.17782612144947052, 0.10976967215538025, 0.1881657987833023, 0.2868414521217346, 0.11732560396194458, 0.26134946942329407, 0.7253008484840393, 0.08226673305034637, 0.008479545824229717, 0.9242714047431946, 0.0, 0.11777501553297043, 0.0, 0.0], [0.04465315118432045, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05943992733955383, 0.0, 0.02031438611447811, 0.07079578191041946, 0.033250801265239716, 1.5401990413665771, 0.7273367047309875, 0.06625092029571533, 0.02427692711353302, 0.031956788152456284, 0.014787783846259117, 0.0, 0.0, 0.0, 0.00579764973372221, 0.010884908027946949, 0.003546688240021467, 0.0, 0.18943770229816437, 0.04781854897737503, 0.162400022149086, 0.09780129045248032, 0.051117051392793655, 0.020457372069358826, 0.0725732073187828, 0.0, 0.0065450421534478664, 0.06454187631607056, 0.0, 0.0, 0.0, 0.0, 0.017369983717799187, 0.43540045619010925, 0.1919867843389511, 0.0, 0.0, 0.0, 0.0015747877769172192, 0.0, 0.0, 0.0, 0.023554794490337372, 0.0, 0.03670415282249451, 0.10220705717802048, 1.6251862049102783, 0.5752202868461609, 0.0, 0.0, 0.13917790353298187, 0.0, 0.12863819301128387, 0.0, 0.16625574231147766, 0.0, 0.0, 0.05460260063409805, 0.0, 0.0, 0.357178658246994, 0.09057365357875824, 0.32140475511550903, 0.16440032422542572, 0.0, 0.19674359261989594, 0.4199453890323639, 0.27811336517333984, 0.0, 0.06316006928682327, 0.0, 0.0, 0.010257151909172535, 0.1841878890991211, 0.06514038890600204, 0.04773882403969765, 0.004216912668198347, 0.06803591549396515, 0.03501274064183235, 0.03025013953447342, 0.012003141455352306, 0.0, 0.0, 0.0, 0.0, 0.004202946554869413, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014488446526229382, 0.08163046091794968, 0.10156448185443878, 1.6222259998321533, 0.748431384563446, 0.026708532124757767, 0.0, 0.0, 0.013119610957801342, 0.0, 0.0, 0.0, 0.02553274855017662, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005429800134152174, 0.0, 0.0, 0.030102873221039772, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.031062833964824677, 0.0, 0.0, 0.032887496054172516, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06436415016651154, 0.0, 0.006211204454302788, 0.0, 0.0, 0.0, 0.0, 0.08202065527439117, 0.07211660593748093, 0.0, 0.0, 1.4295873641967773, 0.5739235877990723, 0.13786247372627258, 0.0605236254632473, 0.0, 0.0, 0.02401999570429325, 0.05403516814112663, 0.03147612512111664, 0.0003033366519957781, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05991251394152641, 0.0, 1.5210920572280884, 0.5586520433425903, 0.0288332961499691, 0.0878724679350853, 0.00963361095637083, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03691845387220383, 0.0, 0.0, 0.029467884451150894, 0.0, 0.0005633205291815102, 0.0, 0.0, 0.0022179691586643457, 0.15820194780826569, 0.09461069852113724, 0.21518683433532715, 0.30396169424057007, 0.32131701707839966, 0.0866575688123703, 0.049838438630104065, 0.0, 0.0, 0.028908468782901764, 0.0, 0.17878997325897217, 0.04046162590384483, 0.0, 0.13778777420520782, 0.31815558671951294, 1.5511397123336792, 1.5511397123336792], [0.04047498106956482, 0.08685029298067093, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06380807608366013, 0.048008956015110016, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15146997570991516, 0.2555634379386902, 0.3440439999103546, 0.166865736246109, 0.02379053272306919, 0.0, 0.2636808753013611, 0.3318542242050171, 0.03128353878855705, 0.0, 0.0, 0.0, 0.04678778350353241, 0.05185417830944061, 0.08794725686311722, 0.002151857130229473, 0.02881965972483158, 0.05098544806241989, 0.0, 0.0, 0.0, 0.0, 0.016245627775788307, 0.0, 0.0, 0.15836389362812042, 0.22445455193519592, 0.2107396274805069, 0.1731887012720108, 0.4014800190925598, 0.38720616698265076, 0.08526390045881271, 0.023173781111836433, 0.0, 0.02540288120508194, 0.11838783323764801, 0.0, 0.07073958218097687, 0.015301251783967018, 0.005081910640001297, 0.057671919465065, 0.0, 0.0, 0.0, 0.012790570966899395, 0.0, 0.1891067773103714, 0.01030360534787178, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0004771618405357003, 0.0, 0.06476779282093048, 0.1553705483675003, 0.015476859174668789, 0.019419781863689423, 0.0356316901743412, 0.0, 0.0, 0.023824337869882584, 0.057649824768304825, 0.0038126977160573006, 0.0, 0.0, 0.0, 0.002463985700160265, 0.0, 0.11620031297206879, 0.24604849517345428, 0.0, 0.39173445105552673, 0.7970678806304932, 0.5829179286956787, 0.293885737657547, 0.7182683348655701, 0.77298903465271, 0.49504268169403076, 0.42017996311187744, 0.4398961067199707, 0.2869652509689331, 0.0, 0.10565944015979767, 0.6207095980644226, 0.6183021068572998, 0.0935974046587944, 0.06718985736370087, 0.0, 0.01152257900685072, 0.0, 0.07557403296232224, 0.054757773876190186, 0.03211569786071777, 0.021239574998617172, 0.0, 0.0, 0.0, 0.07508521527051926, 0.045941468328237534, 0.0, 0.0, 0.0, 0.0, 0.0, 0.19145479798316956, 0.2775093913078308, 0.3571106493473053, 0.20624332129955292, 0.0563783273100853, 0.1551581621170044, 0.012984948232769966, 0.0653936043381691, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01265883818268776, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.029078923165798187, 0.2967977523803711, 0.0, 0.45871272683143616, 0.4287324845790863, 0.4704863131046295, 0.30866602063179016, 0.3572061061859131, 0.3632848560810089, 0.8189705610275269, 0.6294815540313721, 0.0012312268372625113, 0.21633380651474, 0.12833131849765778, 0.2796488106250763, 0.0, 0.0, 0.029511848464608192, 0.0, 0.0, 0.0, 0.0, 0.08101598918437958, 0.19009840488433838, 0.3004223704338074, 0.48100703954696655, 0.7236307859420776, 0.48506462574005127, 0.5329397320747375, 0.23194657266139984, 0.1469089686870575, 0.16067110002040863, 0.0, 0.18008965253829956, 0.0970911756157875, 0.05595199018716812, 0.15025968849658966, 0.10477034002542496, 0.0, 0.0, 0.0, 0.0, 0.2555140554904938, 0.48196855187416077, 0.33499976992607117, 0.0, 0.2425786405801773, 0.19735164940357208, 0.08123593032360077, 0.22391609847545624, 0.34869953989982605, 0.05436002463102341, 0.20118282735347748, 0.10134138911962509, 0.0, 0.0, 0.17191161215305328, 0.03677595406770706, 0.0, 0.0, 0.1288214921951294, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1745818704366684, 0.0, 0.16696381568908691, 0.13567417860031128, 0.013985753990709782, 0.0, 0.13790260255336761, 0.21900257468223572, 0.026878798380494118, 0.07692351192235947, 0.061814241111278534, 0.0, 0.0, 0.12066002190113068, 0.1940702199935913, 0.03172145038843155, 0.1089988723397255, 0.10243146121501923, 0.16511304676532745, 0.09686874598264694, 0.1377723067998886, 0.19517561793327332, 0.41928374767303467, 0.05602443963289261, 0.4669700264930725, 0.04954010993242264, 0.03266987204551697, 0.45752888917922974, 1.051405429840088, 1.1061893701553345, 0.7843966484069824, 1.0852566957473755, 0.33831787109375, 0.08146953582763672, 0.5137521028518677, 0.11885396391153336, 0.0, 0.0, 0.004055188503116369, 0.0, 0.0, 0.0, 0.10289384424686432, 0.04214238375425339, 0.06089932844042778, 0.016734858974814415, 0.0, 0.11332838982343674, 0.0, 0.0, 0.10711441189050674, 0.0, 0.05979199334979057, 0.0, 0.09027957916259766, 0.0, 0.17366261780261993, 0.09453708678483963, 0.0, 0.0, 0.011063958518207073, 0.0, 0.0, 0.0, 0.0, 0.20089462399482727, 0.007807085756212473, 0.1953585147857666, 0.12177278101444244, 0.13334763050079346, 0.3859595060348511, 0.17730103433132172, 0.09112615883350372, 0.11456874012947083, 0.2095981240272522, 0.30183589458465576, 0.21846729516983032, 0.1831885427236557, 0.5155091881752014, 0.45917683839797974, 0.052964113652706146, 0.26675939559936523, 0.09995266795158386, 0.0, 0.0, 0.0, 0.047273777425289154, 0.4251074492931366, 0.2476259022951126, 0.40064093470573425, 0.0, 0.0, 0.0, 0.08782720565795898, 0.0, 0.0, 0.1010480523109436, 0.0, 0.0, 0.0, 0.0, 0.1047593355178833, 0.027176283299922943, 0.0, 0.13336561620235443, 0.0, 0.0020576196257025003, 0.0, 0.16580429673194885, 0.05108529329299927, 0.0, 0.20163145661354065, 0.21706146001815796, 0.288188099861145, 0.007307225372642279, 0.031107716262340546, 0.0250589270144701, 0.01275676116347313, 0.028834009543061256, 0.0, 0.00928716640919447, 0.0, 0.0, 0.036038707941770554, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08339101076126099, 0.07824192941188812, 0.0, 0.00864570401608944, 0.0, 0.0, 0.0, 0.0, 0.03362403064966202, 0.0, 0.0, 0.0, 0.0, 0.010251449421048164, 0.0, 0.019038932397961617, 0.10624637454748154, 0.0, 0.0, 0.0, 0.02582639269530773, 0.0, 0.11021607369184494, 0.6760910153388977, 0.6793335676193237, 0.13503658771514893, 0.007194031961262226, 0.23251309990882874, 0.288104772567749, 0.33590516448020935, 0.09361626952886581, 0.01810881868004799, 0.0, 0.0, 0.03176061436533928, 0.0, 0.030302904546260834, 0.0, 0.06777545809745789, 0.10163422673940659, 0.0, 0.11546176671981812, 0.0, 0.14273859560489655, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04473727568984032, 0.09394452720880508, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.12667717039585114, 0.0, 0.0885111540555954, 0.0, 0.04209299385547638, 0.03018239699304104, 0.0, 0.0, 0.0, 0.08554467558860779, 0.04953128844499588, 0.07724567502737045, 0.01463050302118063, 0.0213308185338974, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.025755897164344788, 0.0, 0.0, 0.045874886214733124, 0.0, 0.0, 0.0, 0.008690961636602879, 0.0019797533750534058, 0.006271644029766321, 0.15869642794132233, 0.1642024964094162, 0.05029218643903732, 0.0, 0.008777376264333725, 0.014514933340251446, 0.14861510694026947, 0.14321155846118927, 0.07590383291244507, 0.16357122361660004, 0.05452634394168854, 0.06287278234958649, 0.18118268251419067, 0.005860454402863979, 0.0954083725810051, 0.09225784242153168, 0.008735689334571362, 0.0, 0.0, 0.0, 0.0, 0.12565916776657104, 0.16702388226985931, 0.02292357012629509, 0.0075993845239281654, 0.17063851654529572, 0.06044883653521538, 0.02822980284690857, 0.27110710740089417, 0.2914012670516968, 0.19231685996055603, 0.22632533311843872, 0.16662068665027618, 0.5038667917251587, 0.3808630704879761, 0.009881541132926941, 0.3092441260814667, 1.1933783292770386, 1.1588793992996216, 0.4838138520717621, 1.1873191595077515, 0.4440177381038666, 1.2367674112319946, 0.35954004526138306, 1.193796992301941, 0.3844605088233948, 0.37414854764938354, 1.1806646585464478, 0.5903279185295105, 0.15684087574481964, 0.12892577052116394, 0.2695196866989136, 0.017884716391563416, 0.0, 0.23270922899246216, 0.2724786698818207, 0.22306561470031738, 0.41929760575294495, 0.28533193469047546, 0.1794268935918808, 0.3049161732196808, 0.25140801072120667, 0.16726738214492798, 0.1023150235414505, 0.16878342628479004, 0.20889875292778015, 0.09051156789064407, 0.06318599730730057, 0.013658443465828896, 0.016241177916526794, 0.06029883399605751, 0.03077465482056141, 0.22686021029949188, 0.0, 0.2172628492116928, 0.0, 0.0, 0.0, 0.0, 0.12827007472515106, 0.28113657236099243, 0.20474028587341309, 0.04563574120402336, 0.2165694236755371, 0.0, 0.0, 0.020326433703303337, 0.17568986117839813, 0.03897322341799736, 0.008923348039388657, 0.0, 0.0, 0.0, 0.0, 0.03889938443899155, 0.02876773104071617, 0.0012311919126659632, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.040584880858659744, 0.0, 0.0, 0.007015481125563383, 0.01639442890882492, 0.0, 0.013307713903486729, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04974696412682533, 0.015381929464638233, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011072504334151745, 0.0, 0.06618978083133698, 0.0, 0.08888617902994156, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09510710090398788, 0.0, 0.05092395097017288, 0.10300863534212112, 0.05260113626718521, 0.0, 0.0, 0.14241333305835724, 0.09872852265834808, 0.08370755612850189, 0.0472029484808445, 0.002121047815307975, 0.02049815095961094, 0.01877514086663723, 0.1293572038412094, 0.05818427354097366, 0.0, 0.0, 0.0, 0.0, 0.04909488186240196, 0.08858338743448257, 0.0, 0.0, 0.06474847346544266, 0.0, 0.09011615812778473, 0.09604338556528091, 0.03836115077137947, 0.0, 0.0, 0.0, 0.0, 0.0, 0.11705490201711655, 0.0, 0.014476346783339977, 0.0, 0.0, 0.010791820473968983, 0.12386217713356018, 0.05287652835249901, 0.13249312341213226, 0.03702722117304802, 0.05859639123082161, 0.0, 0.020553240552544594, 0.06249130517244339, 0.0, 0.0, 0.005225697066634893, 0.0015450246864929795, 0.0, 0.0, 0.0, 0.05710629001259804, 0.1251152753829956, 0.0, 0.0], [0.0, 0.0060430471785366535, 0.0, 0.0, 0.0, 0.0, 0.1547992080450058, 0.0, 0.171248659491539, 0.058960434049367905, 0.08583441376686096, 0.0, 0.09056289494037628, 0.03109041601419449, 0.0, 0.0, 0.01168955396860838, 0.0, 0.006199451629072428, 0.0, 0.0, 0.0, 0.0, 0.01786321960389614, 0.2059308886528015, 0.1500164121389389, 0.41374969482421875, 0.2679852247238159, 0.27889829874038696, 0.27717605233192444, 0.11561661958694458, 0.05323992297053337, 0.008691195398569107, 0.2020750194787979, 0.0, 0.0, 0.0, 0.0, 0.034947242587804794, 0.3013627231121063, 0.15650637447834015, 0.02131090871989727, 0.02103479951620102, 0.11089211702346802, 0.01081389095634222, 0.0, 0.0, 0.0, 0.27210691571235657, 0.10956434905529022, 0.31837227940559387, 0.08617620170116425, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015123449265956879, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015699921175837517, 0.0, 0.20739884674549103, 0.0, 0.0, 0.13966891169548035, 0.29280829429626465, 0.0532529279589653, 0.0, 0.045696720480918884, 0.0, 0.0, 0.6132872104644775, 0.4642932415008545, 0.17187783122062683, 0.08494706451892853, 0.0, 0.1372898370027542, 0.14765650033950806, 0.007072612177580595, 0.0, 0.0, 0.02488604187965393, 0.03170816972851753, 0.0, 0.02577396109700203, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006218187510967255, 0.03765098750591278, 0.0038214675150811672, 0.06135932728648186, 0.0, 0.027989879250526428, 0.0, 0.0, 0.0, 0.0, 0.01724536158144474, 0.05596877634525299, 0.0, 0.34202438592910767, 0.31859084963798523, 0.1735289841890335, 0.07293520122766495, 0.0729956179857254, 0.0, 0.0, 0.058978378772735596, 0.020886491984128952, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0007240427075885236, 0.004900150001049042, 0.026511017233133316, 0.0, 0.0, 0.04217008873820305, 0.0480426549911499, 0.027214912697672844, 0.0060246530920267105, 0.6467710733413696, 0.3956632912158966, 0.8667893409729004, 0.6832785606384277, 0.3489840030670166, 0.29255154728889465, 0.7085409760475159, 0.4674629867076874, 0.8553178310394287, 0.4840604066848755, 0.5323773622512817, 0.4411521852016449, 0.3325031101703644, 0.2476603388786316, 0.34963804483413696, 0.6593136191368103, 0.5467184782028198, 0.2722621262073517, 0.07766591757535934, 0.0, 0.02816377766430378, 0.0, 0.0, 0.0, 0.061832938343286514, 0.0, 0.0, 0.0442662313580513, 0.0, 0.07645173370838165, 0.0, 0.032538894563913345, 0.0, 0.058446917682886124, 0.21685628592967987, 0.19616352021694183, 0.18996940553188324, 0.165039524435997, 0.01917773298919201, 0.06034384295344353, 0.05969908460974693, 0.1089283749461174, 0.04464757442474365, 0.0, 0.007003579754382372, 0.0, 0.0, 0.6844903826713562, 0.7346139550209045, 0.015916593372821808, 0.30672910809516907, 0.43664276599884033, 0.13517510890960693, 0.17148418724536896, 0.11377346515655518, 0.05163727328181267, 0.17662493884563446, 0.04342302680015564, 0.0, 0.02800217643380165, 0.04403850436210632, 0.12380943447351456, 0.0, 0.1699092835187912, 0.024798693135380745, 0.18928278982639313, 0.23655752837657928, 0.10899604856967926, 0.14101529121398926, 0.15613356232643127, 0.0, 0.0, 0.04537384957075119, 0.03714904561638832, 0.005229146685451269, 0.0, 0.0, 0.019143138080835342, 0.0, 0.08267994225025177, 0.07609318196773529, 0.0, 0.7626792192459106, 0.3513638377189636, 0.0, 0.0], [0.17459605634212494, 0.0, 0.06537389010190964, 0.6833633780479431, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.11711958050727844, 0.0, 0.0, 0.0, 0.013237472623586655, 0.02280307374894619, 0.017957985401153564, 0.0, 0.0, 0.0, 0.40972867608070374, 0.0, 0.02088172361254692, 0.0, 0.0, 0.0, 0.0, 0.05187712982296944, 0.0, 0.0, 0.0, 0.21089714765548706, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.038351621478796005, 0.0, 0.0, 0.0, 0.1387951672077179, 0.5420678853988647, 0.01619267649948597, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02560783550143242, 0.0, 0.0038389775436371565, 0.0, 0.004132810980081558, 0.10075072199106216, 0.0, 0.0, 0.5840738415718079, 1.0885075330734253, 0.5222513675689697, 0.9900389313697815, 1.5903747081756592, 0.1974935233592987, 0.023100612685084343, 0.0, 0.0, 0.06539809703826904, 0.04535119980573654, 0.020962636917829514, 0.0, 0.0, 0.0012148416135460138, 0.0, 0.08345607668161392, 0.16515274345874786, 0.01968264766037464, 0.0044713690876960754, 0.03691043704748154, 0.25143110752105713, 0.016762910410761833, 0.0, 0.0, 0.0, 0.019724490121006966, 0.03595700114965439, 0.5394142270088196, 0.019672095775604248, 0.0, 0.0, 0.0, 0.0007596493232995272, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13558831810951233, 0.6253993511199951, 0.0, 0.0, 0.010444290935993195, 0.11835417151451111, 0.5281598567962646, 0.2149064540863037, 0.8267276883125305, 1.2662497758865356, 0.012264636345207691, 0.0, 0.0, 0.0, 0.0, 0.074116550385952, 0.21650449931621552, 0.021032441407442093, 0.00465177558362484, 0.016848484054207802, 0.09480636566877365, 0.058765001595020294, 0.0, 0.0, 0.0, 0.0, 0.0837516039609909, 0.45111164450645447, 0.05329408496618271, 0.0, 0.049374550580978394, 0.0, 0.0, 0.34201836585998535, 0.0, 0.010928566567599773, 0.0, 0.0, 0.12304079532623291, 0.551660418510437, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004817667417228222, 0.008522886782884598, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05447052791714668, 0.0, 0.04604212939739227, 0.03327266499400139, 0.0, 0.026181628927588463, 0.0, 0.0, 0.0, 0.0, 0.01109134592115879, 0.0, 0.0, 0.028675472363829613, 0.0, 0.0, 0.15205295383930206, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008543439209461212, 0.2433745563030243, 0.03790862858295441, 0.0, 0.0, 0.012881780974566936, 0.0, 0.0, 0.0, 0.027364911511540413, 0.0, 0.0, 0.17111286520957947, 0.7014391422271729, 0.0036086426116526127, 0.0, 0.1582627296447754, 0.5398176908493042, 0.0, 0.0, 0.0, 0.0, 0.0], [0.01606942154467106, 0.18430303037166595, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03806814178824425, 0.0, 0.0, 0.0, 0.12682363390922546, 0.16093029081821442, 0.12198193371295929, 0.034307945519685745, 0.0, 0.0, 0.17340421676635742, 0.3951360881328583, 0.2054634690284729, 0.06553316116333008, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024493670091032982, 0.0, 0.14488665759563446, 0.09912709891796112, 0.0009062399622052908, 0.053090233355760574, 0.0, 0.04860958456993103, 0.030811013653874397, 0.0, 0.0, 0.0, 0.0015993124106898904, 0.0, 0.0, 0.015932483598589897, 0.0, 0.0, 0.0, 0.006761179771274328, 0.0, 0.0, 0.012854182161390781, 0.0, 0.0038081577513366938, 0.0, 0.0, 0.027861211448907852, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1411944329738617, 0.0, 0.0, 0.033895667642354965, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.14096735417842865, 0.3244544267654419, 0.09052922576665878, 0.13588552176952362, 0.19965460896492004, 0.08197063207626343, 0.06683650612831116, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.07492049783468246, 0.0, 0.0, 0.11113569140434265, 0.02063245326280594, 0.0, 0.03331528231501579, 0.0, 0.019863709807395935, 0.0, 0.0, 0.13878431916236877, 0.149375319480896, 0.280863881111145, 0.13362519443035126, 0.35532304644584656, 0.1954927146434784, 0.08299227058887482, 0.36414676904678345, 0.5039342045783997, 0.6674075126647949, 1.0510234832763672, 0.8971772789955139, 0.6416287422180176, 0.7211648225784302, 0.22739183902740479, 0.09528860449790955, 0.16403821110725403, 0.2346271574497223, 0.5971817374229431, 0.26015859842300415, 0.07486922293901443, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.025051891803741455, 0.0, 0.0, 0.0, 0.0, 0.0019155166810378432, 0.0014396619517356157, 0.07664024084806442, 0.11027966439723969, 0.07499732077121735, 0.0, 0.0, 0.0, 0.130168154835701, 0.02027016319334507, 0.0, 0.0, 0.28256142139434814, 0.3784732520580292, 0.6680771112442017, 0.42120304703712463, 0.29430317878723145, 0.0, 0.0, 0.0, 0.0, 0.21932269632816315, 0.13669010996818542, 0.1993417739868164, 0.06864720582962036, 0.19065257906913757, 0.4280717372894287, 0.24251939356327057, 0.22277434170246124, 0.29151323437690735, 0.24577055871486664, 0.16902683675289154, 0.01002406980842352, 0.04763028398156166, 0.0, 0.18420246243476868, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05161944776773453, 0.18689978122711182, 0.4663838744163513, 0.43926969170570374, 0.6573739647865295, 0.9954114556312561, 1.0990484952926636, 1.0985662937164307, 0.843561589717865, 0.3490009307861328, 0.05521465837955475, 0.01663590595126152, 0.0, 0.14187736809253693, 0.14557763934135437, 0.29808950424194336, 0.1958625465631485, 0.019274335354566574, 0.09065769612789154, 0.07013768702745438, 0.2288208305835724, 0.0431673564016819, 0.0743127316236496, 0.11049745231866837, 0.39993932843208313, 0.5197175741195679, 0.26998844742774963, 0.22305628657341003, 0.14558885991573334, 0.2014445662498474, 0.14641915261745453, 0.01645803265273571, 0.01931154541671276, 0.09892692416906357, 0.0023670238442718983, 0.0023670238442718983], [0.4311433434486389, 0.8852853775024414, 1.3041034936904907, 0.8154964447021484, 1.5183829069137573, 1.4228448867797852, 0.8213437795639038, 0.9953823685646057, 0.7603039145469666, 0.4416096806526184, 0.49492302536964417, 0.12444088608026505, 0.26161980628967285, 0.3970169425010681, 0.32328301668167114, 0.29510945081710815, 0.2760668396949768, 0.2224775105714798, 0.19017024338245392, 0.2741832435131073, 0.2743110656738281, 0.2722814679145813, 0.2522200345993042, 0.17350873351097107, 0.034611523151397705, 0.0, 0.034074567258358, 0.018781958147883415, 0.012903173454105854, 0.012343933805823326, 0.053999755531549454, 0.049181267619132996, 0.06351105868816376, 0.08747036755084991, 0.0, 0.0, 0.0, 0.0, 0.01226121000945568, 0.007587820291519165, 0.0, 0.05301247164607048, 0.059992775321006775, 0.07238741219043732, 0.1406201422214508, 0.08367867022752762, 0.04133915156126022, 0.08789995312690735, 0.02532922849059105, 0.0, 0.005815573036670685, 0.0, 0.0, 0.0, 0.0, 0.004298526793718338, 0.005610503256320953, 0.0, 0.005548693239688873, 0.0, 0.02004011906683445, 0.0, 0.0, 0.014636719599366188, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008367737755179405, 0.0033936179243028164, 0.08312568068504333, 0.04459008947014809, 0.0, 0.0, 0.03320648893713951, 0.07892857491970062, 0.0, 0.0, 0.04871990531682968, 0.0, 0.18616296350955963, 0.0, 0.04089759290218353, 0.0, 0.0, 0.015875276178121567, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05564867705106735, 0.026475833728909492, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.036765359342098236, 0.0, 0.0, 0.0, 0.06154908984899521, 0.24435937404632568, 0.16658353805541992, 0.12099756300449371, 0.035375118255615234, 0.0, 0.0, 0.0, 0.05795987695455551, 0.0, 0.003679705085232854, 0.0, 0.05195022001862526, 0.16321276128292084, 0.0, 0.0, 0.0, 0.0, 0.008823509328067303, 0.0, 0.0, 0.0, 0.0, 0.03264571353793144, 0.017319858074188232, 0.0, 0.0, 0.0, 0.0, 0.014602471143007278, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005173415411263704, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06812996417284012, 0.0, 0.0, 0.0, 0.006358534563332796, 0.0010379053419455886, 0.0, 0.0, 0.0, 0.0, 0.01544839609414339, 0.28396034240722656, 0.0, 0.0, 0.0, 0.0, 0.0, 0.041920799762010574, 0.029963701963424683, 0.03273793309926987, 0.0, 0.0, 0.0, 0.0, 0.0025173183530569077, 0.0, 0.0, 0.0, 0.0, 0.15936420857906342, 0.18755289912223816, 0.1257696896791458, 0.0606636181473732, 0.03731745108962059, 0.0, 0.005794433876872063, 0.08525928854942322, 0.06829321384429932, 0.04454120993614197, 0.0, 0.03594287112355232, 0.023587508127093315, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.2106902301311493, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008115069009363651, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.24544528126716614, 0.052649859338998795, 0.02638624608516693, 0.015571951866149902, 0.003232126124203205, 0.0, 0.0, 0.23511122167110443, 0.0, 0.0, 0.0, 0.014202823862433434, 0.0, 0.015668390318751335, 0.0, 0.0, 0.0, 0.0, 0.012124394997954369, 0.0, 0.0, 0.0, 0.004718458279967308, 0.0, 0.015230025164783001, 0.0, 0.014372866600751877, 0.06000981107354164, 0.05472797155380249, 0.05747835710644722, 0.0528034046292305, 0.010582861490547657, 0.004372255876660347, 0.017137760296463966, 0.056507356464862823, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04804875701665878, 0.047465622425079346, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0002696122392080724, 0.07400622963905334, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03703653812408447, 0.0, 0.0, 0.0, 0.0, 0.0, 0.016034439206123352, 0.0, 0.0, 0.0, 0.0, 0.0001815393043216318, 0.0, 0.02327195554971695, 0.0, 0.0, 0.022362705320119858, 0.25130695104599, 0.04412965849041939, 0.0582464337348938, 0.059868376702070236, 1.9280487298965454, 0.036543745547533035, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009225546382367611, 0.013114024884998798, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0011392069282010198, 0.0, 0.026719221845269203, 0.0, 0.0, 0.0, 0.0, 0.0042528025805950165, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09649287164211273, 0.23084260523319244, 0.08895086497068405, 0.08357802778482437, 0.11147691309452057, 0.03976967930793762, 0.0467519573867321, 0.0, 0.0, 0.03684183210134506, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03957170620560646, 0.0, 0.0, 0.0, 0.0, 0.014731500297784805, 0.0, 0.0, 0.028190825134515762, 0.0, 0.0, 0.0, 0.0, 0.024105165153741837, 0.08409683406352997, 1.6416269540786743, 0.07974804937839508, 0.0, 0.0, 0.0, 0.0, 0.015796221792697906, 0.0, 0.0, 0.02612893655896187, 0.0, 0.018395405262708664, 0.0, 0.015024205669760704, 0.008104363456368446, 0.0, 0.03244274854660034, 0.020237386226654053, 0.008001020178198814, 0.07801033556461334, 0.10715416073799133, 0.10461953282356262, 0.07644226402044296, 0.06877924501895905, 0.0, 0.0, 0.0, 0.041044849902391434, 0.0, 0.0, 0.00040476705180481076, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.016656136140227318, 0.057654865086078644, 0.07494476437568665, 1.6643496751785278, 0.07809551805257797, 0.06442951411008835, 0.002679255325347185, 0.0, 0.004283064976334572, 0.007170452736318111, 0.008573337458074093, 0.04804740101099014, 0.008885066956281662, 0.04586372151970863, 0.004367036744952202, 0.0, 0.0, 0.0, 0.0, 0.0, 0.018327167257666588, 0.0, 0.0, 0.011022468097507954, 0.009522870182991028, 0.0, 0.0]]]})\n",
+              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[0.0, 0.0, 0.0, 0.0, 0.037870489060878754, 0.05019696056842804, 0.0, 0.24998080730438232, 0.0, 0.02050243690609932, 0.20176677405834198, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.001779860001988709, 0.0, 0.0, 0.0, 0.0, 0.06486152112483978, 0.1417006105184555, 0.028251629322767258, 0.08057409524917603, 0.01198999211192131, 0.0, 0.16921266913414001, 0.06969344615936279, 0.5606383085250854, 0.47294512391090393, 0.0, 0.0, 0.0, 0.021539991721510887, 0.0, 0.17053674161434174, 0.08799529075622559, 0.0, 0.0, 0.0, 0.06157722324132919, 0.18085983395576477, 0.041201669722795486, 0.03461650386452675, 0.507945716381073, 0.0, 0.0, 0.0, 0.1394190788269043, 0.0, 0.0, 0.014230618253350258, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01773686893284321, 0.0, 0.0, 0.49114516377449036, 0.0018696392653509974, 0.0, 0.0, 0.053380172699689865, 0.0, 0.0, 0.02366033010184765, 0.0, 0.0024169483222067356, 0.17631548643112183, 0.11772141605615616, 0.2671918570995331, 0.0, 0.0, 0.0, 0.02899119444191456, 0.25468823313713074, 0.024462558329105377, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01398562453687191, 0.0571276918053627, 0.24653016030788422, 0.0, 0.0, 0.0, 0.0005369762075133622, 0.6003664135932922, 0.7200817465782166, 0.3476112484931946, 0.1265842467546463, 0.9570865631103516, 0.0, 0.16010169684886932, 0.15017330646514893, 0.00849861092865467, 0.02719499170780182, 0.049060918390750885, 0.0, 0.0, 0.022402750328183174, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08942243456840515, 0.049005910754203796, 0.0501575693488121, 0.064661905169487, 0.1812911331653595, 0.41189175844192505, 0.6073496341705322, 0.9057233333587646, 0.005141559988260269, 0.0, 0.0, 0.0, 0.2672904133796692, 0.6534031629562378, 0.05332382395863533, 0.0, 0.02293715439736843, 0.0, 0.0, 0.1885221153497696, 0.15873360633850098, 0.02294679544866085, 0.6222780346870422, 0.13872875273227692, 0.2762048840522766, 0.0, 0.005263698752969503, 0.0, 0.04662656784057617, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011234414763748646, 0.0, 0.06738311052322388, 0.2071012705564499, 0.2102581411600113, 0.10976310819387436, 0.007388463243842125, 0.24433107674121857, 0.05049098655581474, 0.0, 0.0, 0.004548593889921904, 0.00381899019703269, 0.021703166887164116, 0.0030421651899814606, 0.0, 0.0, 0.07319701462984085, 0.26357629895210266, 0.5262628793716431, 0.0, 0.0, 0.0, 0.0, 0.040956560522317886, 0.0, 0.0, 0.0, 0.02724297344684601, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011121110059320927, 0.0, 0.049851350486278534, 0.13904547691345215, 0.0, 0.0, 0.057656265795230865, 0.050849560648202896, 0.05037802457809448, 0.17769433557987213, 0.5119072198867798, 0.17275658249855042, 0.10664107650518417, 0.18280643224716187, 0.2786664366722107, 0.11398203670978546, 0.25390195846557617, 0.7046341300010681, 0.07992180436849594, 0.0082377465441823, 0.8979293704032898, 0.0, 0.11442916095256805, 0.0, 0.0], [0.042955998331308365, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0571809746325016, 0.0, 0.019542448222637177, 0.06810539960861206, 0.03199028968811035, 1.4816612005233765, 0.6996951699256897, 0.06373181194067001, 0.023354405537247658, 0.030741684138774872, 0.014226402156054974, 0.0, 0.0, 0.0, 0.005576997995376587, 0.0104708606377244, 0.003411458572372794, 0.0, 0.18224561214447021, 0.04600358009338379, 0.15623843669891357, 0.09408747404813766, 0.04917951673269272, 0.019689831882715225, 0.06981688737869263, 0.0, 0.006300111301243305, 0.06209154427051544, 0.0, 0.0, 0.0, 0.0, 0.01671542413532734, 0.4188663363456726, 0.1846933513879776, 0.0, 0.0, 0.0, 0.0015191835118457675, 0.0, 0.0, 0.0, 0.02266315370798111, 0.0, 0.035315174609422684, 0.09832993894815445, 1.5634206533432007, 0.553360104560852, 0.0, 0.0, 0.13388842344284058, 0.0, 0.12374728918075562, 0.0, 0.15993623435497284, 0.0, 0.0, 0.05252574011683464, 0.0, 0.0, 0.34360000491142273, 0.08713007718324661, 0.3091903030872345, 0.15815111994743347, 0.0, 0.1892680525779724, 0.4039972722530365, 0.2675463557243347, 0.0, 0.06076255813241005, 0.0, 0.0, 0.009877387434244156, 0.17719608545303345, 0.06266660988330841, 0.045926209539175034, 0.004057501908391714, 0.0654522106051445, 0.03368153050541878, 0.02909718081355095, 0.011546161957085133, 0.0, 0.0, 0.0, 0.0, 0.00404777005314827, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.013943132013082504, 0.07852881401777267, 0.09771120548248291, 1.5605709552764893, 0.7199861407279968, 0.025692114606499672, 0.0, 0.0, 0.012619346380233765, 0.0, 0.0, 0.0, 0.02456221543252468, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00522377947345376, 0.0, 0.0, 0.028956402093172073, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02988049015402794, 0.0, 0.0, 0.03163697198033333, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.061916038393974304, 0.0, 0.005974378902465105, 0.0, 0.0, 0.0, 0.0, 0.07890306413173676, 0.06937293708324432, 0.0, 0.0, 1.37525475025177, 0.5521166920661926, 0.13262420892715454, 0.058228518813848495, 0.0, 0.0, 0.023116648197174072, 0.051987361162900925, 0.030282989144325256, 0.0002942906867247075, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05764263868331909, 0.0, 1.463282585144043, 0.537420928478241, 0.027747225016355515, 0.08453439176082611, 0.009273014031350613, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03551304712891579, 0.0, 0.0, 0.028347743675112724, 0.0, 0.0005446687573567033, 0.0, 0.0, 0.002139216987416148, 0.15219318866729736, 0.09101938456296921, 0.20700883865356445, 0.2924094498157501, 0.3091028034687042, 0.08336605131626129, 0.047946687787771225, 0.0, 0.0, 0.02781251259148121, 0.0, 0.17199407517910004, 0.038922883570194244, 0.0, 0.13256047666072845, 0.3060738742351532, 1.4921875, 1.4921875], [0.042643602937459946, 0.09151230752468109, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06722043454647064, 0.05058203637599945, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1595936417579651, 0.26927390694618225, 0.36250320076942444, 0.17580847442150116, 0.025065777823328972, 0.0, 0.277812123298645, 0.3496432304382324, 0.032966505736112595, 0.0, 0.0, 0.0, 0.0493013896048069, 0.05464604124426842, 0.09265891462564468, 0.002271034521982074, 0.030368072912096977, 0.05372057110071182, 0.0, 0.0, 0.0, 0.0, 0.017121341079473495, 0.0, 0.0, 0.16685348749160767, 0.23649872839450836, 0.2220439910888672, 0.18247371912002563, 0.4230109453201294, 0.4079740643501282, 0.08983665704727173, 0.024423927068710327, 0.0, 0.02677561156451702, 0.12473994493484497, 0.0, 0.07453498989343643, 0.016134971752762794, 0.005361618008464575, 0.060765381902456284, 0.0, 0.0, 0.0, 0.013476202264428139, 0.0, 0.1992391049861908, 0.010850803926587105, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0005032062763348222, 0.0, 0.06824170798063278, 0.16370530426502228, 0.016308020800352097, 0.020456893369555473, 0.03754206374287605, 0.0, 0.0, 0.02510417066514492, 0.06074336916208267, 0.004016061779111624, 0.0, 0.0, 0.0, 0.002597167855128646, 0.0, 0.12243068218231201, 0.2592514753341675, 0.0, 0.4127373993396759, 0.8397430181503296, 0.614078164100647, 0.30957821011543274, 0.756669819355011, 0.8144181370735168, 0.5215929746627808, 0.44270795583724976, 0.4634586572647095, 0.3023494482040405, 0.0, 0.1113189309835434, 0.6539820432662964, 0.6514529585838318, 0.09861055761575699, 0.07078790664672852, 0.0, 0.012128527276217937, 0.0, 0.0796303004026413, 0.05770401656627655, 0.03384117782115936, 0.022378023713827133, 0.0, 0.0, 0.0, 0.07911378145217896, 0.048410940915346146, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2017192840576172, 0.29239699244499207, 0.37625688314437866, 0.21730245649814606, 0.05940362438559532, 0.1634758710861206, 0.013678519986569881, 0.06889861077070236, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.013340923003852367, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03063987009227276, 0.31271934509277344, 0.0, 0.4833119213581085, 0.4516935348510742, 0.49567919969558716, 0.3251933753490448, 0.37632712721824646, 0.3827274441719055, 0.8628532886505127, 0.6632339358329773, 0.0012972811236977577, 0.22794190049171448, 0.13521501421928406, 0.2946521043777466, 0.0, 0.0, 0.031107386574149132, 0.0, 0.0, 0.0, 0.0, 0.0853637084364891, 0.20029453933238983, 0.3165416419506073, 0.5068003535270691, 0.7623786330223083, 0.5110429525375366, 0.5614679455757141, 0.24436528980731964, 0.15478767454624176, 0.16928867995738983, 0.0, 0.18973056972026825, 0.10230933874845505, 0.058939363807439804, 0.15832273662090302, 0.11039569228887558, 0.0, 0.0, 0.0, 0.0, 0.26918789744377136, 0.5077913999557495, 0.35297149419784546, 0.0, 0.255590558052063, 0.20792542397975922, 0.08559378981590271, 0.23592989146709442, 0.36741065979003906, 0.057280637323856354, 0.21197864413261414, 0.106777623295784, 0.0, 0.0, 0.18113553524017334, 0.03875943645834923, 0.0, 0.0, 0.13573621213436127, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.12985123693943024, 0.0, 0.04861602187156677, 0.5082332491874695, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08710630983114243, 0.0, 0.0, 0.0, 0.009842910803854465, 0.01695406809449196, 0.01335613988339901, 0.0, 0.0, 0.0, 0.30472996830940247, 0.0, 0.015532675199210644, 0.0, 0.0, 0.0, 0.0, 0.038583096116781235, 0.0, 0.0, 0.0, 0.1568564623594284, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.028523355722427368, 0.0, 0.0, 0.0, 0.10322186350822449, 0.4031495749950409, 0.01204217690974474, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.019043663516640663, 0.0, 0.0028547521214932203, 0.0, 0.003076038556173444, 0.07493531703948975, 0.0, 0.0, 0.43439361453056335, 0.80955570936203, 0.38841602206230164, 0.7363170385360718, 1.1828068494796753, 0.1468847692012787, 0.017185572534799576, 0.0, 0.0, 0.04863819479942322, 0.03372969478368759, 0.015590216964483261, 0.0, 0.0, 0.0009024485480040312, 0.0, 0.062066301703453064, 0.12282676994800568, 0.01463598757982254, 0.0033243687357753515, 0.027451694011688232, 0.1869972199201584, 0.012463291175663471, 0.0, 0.0, 0.0, 0.01469122339040041, 0.026804476976394653, 0.4012325704097748, 0.014700551517307758, 0.0, 0.0, 0.0, 0.0005697798915207386, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.10084526985883713, 0.46513667702674866, 0.0, 0.0, 0.007767543662339449, 0.08801865577697754, 0.39280301332473755, 0.15982265770435333, 0.6148409843444824, 0.9417312145233154, 0.009115980938076973, 0.0, 0.0, 0.0, 0.0, 0.05512263625860214, 0.1610233634710312, 0.015638498589396477, 0.0034534393344074488, 0.01252693310379982, 0.07050585746765137, 0.04370352253317833, 0.0, 0.0, 0.0, 0.0, 0.062280673533678055, 0.3354978859424591, 0.039628852158784866, 0.0, 0.03671218082308769, 0.0, 0.0, 0.2543623447418213, 0.0, 0.008121049962937832, 0.0, 0.0, 0.09150433540344238, 0.41028475761413574, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.003587460843846202, 0.006349408533424139, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0405079647898674, 0.0, 0.0342295840382576, 0.024739904329180717, 0.0, 0.019470375031232834, 0.0, 0.0, 0.0, 0.0, 0.008242939598858356, 0.0, 0.0, 0.021341297775506973, 0.0, 0.0, 0.11308617144823074, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006352281663566828, 0.18099921941757202, 0.028190722689032555, 0.0, 0.0, 0.009574891068041325, 0.0, 0.0, 0.0, 0.0203520730137825, 0.0, 0.0, 0.12725917994976044, 0.5216790437698364, 0.002678797347471118, 0.0, 0.11770438402891159, 0.40147894620895386, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2098703533411026, 0.0, 0.2007121443748474, 0.1631016880273819, 0.016817519441246986, 0.0, 0.1657782644033432, 0.2632708251476288, 0.032314784824848175, 0.09247525036334991, 0.07431010901927948, 0.0, 0.0, 0.1450466513633728, 0.23329311609268188, 0.03813629224896431, 0.13103410601615906, 0.12314340472221375, 0.19848819077014923, 0.11644834280014038, 0.1656232625246048, 0.2346283495426178, 0.5040338635444641, 0.06735218316316605, 0.5613567233085632, 0.05955394729971886, 0.03927325829863548, 0.5500078797340393, 1.2639033794403076, 1.3297663927078247, 0.9429292678833008, 1.3046025037765503, 0.4067004323005676, 0.0979384332895279, 0.6175931692123413, 0.14287838339805603, 0.0, 0.0, 0.004876346793025732, 0.0, 0.0, 0.0, 0.12369132786989212, 0.05066012963652611, 0.07321292906999588, 0.020122000947594643, 0.0, 0.13623720407485962, 0.0, 0.0, 0.12876717746257782, 0.0, 0.07187794893980026, 0.0, 0.10852930694818497, 0.0, 0.20876970887184143, 0.11364864557981491, 0.0, 0.0, 0.013299183920025826, 0.0, 0.0, 0.0, 0.0, 0.24150381982326508, 0.009386547841131687, 0.23484806716442108, 0.1463874727487564, 0.1602988839149475, 0.4639696180820465, 0.21313893795013428, 0.10955026000738144, 0.13772991299629211, 0.25196364521980286, 0.36284416913986206, 0.2626258134841919, 0.2202133685350418, 0.6197059750556946, 0.5519887804985046, 0.06367241591215134, 0.32068005204200745, 0.12015636265277863, 0.0, 0.0, 0.0, 0.05684494599699974, 0.5110610723495483, 0.297693133354187, 0.4816555082798004, 0.0, 0.0, 0.0, 0.10558797419071198, 0.0, 0.0, 0.121475450694561, 0.0, 0.0, 0.0, 0.0, 0.12593168020248413, 0.03266863524913788, 0.0, 0.16031894087791443, 0.0, 0.0024666415993124247, 0.0, 0.1993001401424408, 0.0613936185836792, 0.0, 0.2423783242702484, 0.2609255909919739, 0.3464357554912567, 0.008785993792116642, 0.037399906665086746, 0.030129024758934975, 0.01534110028296709, 0.03466262295842171, 0.0, 0.011163217015564442, 0.0, 0.0, 0.04332476109266281, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.10024373233318329, 0.09405305236577988, 0.0, 0.010391266085207462, 0.0, 0.0, 0.0, 0.0, 0.040418460965156555, 0.0, 0.0, 0.0, 0.0, 0.01233215257525444, 0.0, 0.022900255396962166, 0.12773533165454865, 0.0, 0.0, 0.0, 0.031045645475387573, 0.0, 0.13248984515666962, 0.8127217888832092, 0.8166301250457764, 0.16232746839523315, 0.008643080480396748, 0.27950340509414673, 0.34633082151412964, 0.40379464626312256, 0.11253728717565536, 0.02176850102841854, 0.0, 0.0, 0.038192860782146454, 0.0, 0.036444395780563354, 0.0, 0.08148118853569031, 0.12218526750802994, 0.0, 0.13880880177021027, 0.0, 0.1715874969959259, 0.0, 0.0, 0.0, 0.0, 0.0, 0.053781770169734955, 0.11294497549533844, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15227504074573517, 0.0, 0.10639861226081848, 0.0, 0.05060052126646042, 0.03628141060471535, 0.0, 0.0, 0.0, 0.10283157974481583, 0.05953650176525116, 0.09285687655210495, 0.017585447058081627, 0.02563811093568802, 0.0, 0.0, 0.0, 0.0], [0.0, 0.006045951973646879, 0.0, 0.0, 0.0, 0.0, 0.1550873965024948, 0.0, 0.1715681105852127, 0.05906783044338226, 0.085987389087677, 0.0, 0.0907277762889862, 0.031148526817560196, 0.0, 0.0, 0.011705754324793816, 0.0, 0.006188580766320229, 0.0, 0.0, 0.0, 0.0, 0.017881885170936584, 0.206305131316185, 0.15029455721378326, 0.4145107865333557, 0.2684805393218994, 0.2794117331504822, 0.27766942977905273, 0.11582832038402557, 0.05333014577627182, 0.008697008714079857, 0.20244814455509186, 0.0, 0.0, 0.0, 0.0, 0.03500235080718994, 0.3019108474254608, 0.1567954421043396, 0.02134724333882332, 0.021058106794953346, 0.11107534170150757, 0.01081714779138565, 0.0, 0.0, 0.0, 0.272610604763031, 0.10977260768413544, 0.3189607858657837, 0.0863250344991684, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015157228335738182, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01574086584150791, 0.0, 0.20779430866241455, 0.0, 0.0, 0.1399322748184204, 0.2933422029018402, 0.053350046277046204, 0.0, 0.045779891312122345, 0.0, 0.0, 0.614422082901001, 0.46515095233917236, 0.17219634354114532, 0.08510284125804901, 0.0, 0.1375497281551361, 0.14793537557125092, 0.00709069287404418, 0.0, 0.0, 0.024930866435170174, 0.03175004571676254, 0.0, 0.02580592967569828, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006205606274306774, 0.0377032607793808, 0.0038193713407963514, 0.06145905703306198, 0.0, 0.028038086369633675, 0.0, 0.0, 0.0, 0.0, 0.017282789573073387, 0.056079547852277756, 0.0, 0.3426559865474701, 0.3191598355770111, 0.1738341599702835, 0.07306185364723206, 0.07311530411243439, 0.0, 0.0, 0.0590803325176239, 0.020919334143400192, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0007230879855342209, 0.004893898032605648, 0.0265516210347414, 0.0, 0.0, 0.04224374145269394, 0.0481315553188324, 0.02726413495838642, 0.0060415444895625114, 0.647986650466919, 0.39640888571739197, 0.8684109449386597, 0.6845537424087524, 0.34964242577552795, 0.29311585426330566, 0.7098754048347473, 0.46834370493888855, 0.856924295425415, 0.484965980052948, 0.5333699584007263, 0.44197943806648254, 0.3331311047077179, 0.24812620878219604, 0.35030364990234375, 0.6605499982833862, 0.5477429032325745, 0.2727699279785156, 0.07779275625944138, 0.0, 0.028194675222039223, 0.0, 0.0, 0.0, 0.06194212660193443, 0.0, 0.0, 0.04432268440723419, 0.0, 0.07657655328512192, 0.0, 0.032581694424152374, 0.0, 0.05855557695031166, 0.21723803877830505, 0.19651399552822113, 0.19031713902950287, 0.16534171998500824, 0.019214430823922157, 0.06045176461338997, 0.05980176106095314, 0.10910888761281967, 0.04470810666680336, 0.0, 0.007009078748524189, 0.0, 0.0, 0.6857494115829468, 0.7359651327133179, 0.015943750739097595, 0.3072906732559204, 0.4374227523803711, 0.13541483879089355, 0.17178116738796234, 0.1139664277434349, 0.05172129347920418, 0.176939457654953, 0.04349495470523834, 0.0, 0.028051704168319702, 0.044114213436841965, 0.12401534616947174, 0.0, 0.1701948493719101, 0.02482650801539421, 0.1896192729473114, 0.2369758039712906, 0.10917321592569351, 0.1412697434425354, 0.15640833973884583, 0.0, 0.0, 0.045460790395736694, 0.03720859810709953, 0.005228955764323473, 0.0, 0.0, 0.01917191594839096, 0.0, 0.08283459395170212, 0.07623706012964249, 0.0, 0.7640860080718994, 0.35200512409210205, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027198586612939835, 0.0, 0.0, 0.048435937613248825, 0.0, 0.0, 0.0, 0.009177254512906075, 0.002090487629175186, 0.006619930732995272, 0.16757085919380188, 0.17338593304157257, 0.053102828562259674, 0.0, 0.009268979541957378, 0.015321378596127033, 0.15692605078220367, 0.1512153148651123, 0.08014682680368423, 0.17271405458450317, 0.05757318064570427, 0.06638363748788834, 0.19130925834178925, 0.006181037053465843, 0.10073819756507874, 0.09741204977035522, 0.009217341430485249, 0.0, 0.0, 0.0, 0.0, 0.13267925381660461, 0.17635603249073029, 0.024200528860092163, 0.008022075518965721, 0.18018829822540283, 0.06382255256175995, 0.02980034053325653, 0.2862723469734192, 0.30770227313041687, 0.20307952165603638, 0.23899196088314056, 0.17594927549362183, 0.532072126865387, 0.40217381715774536, 0.010432200506329536, 0.32655468583106995, 1.2602014541625977, 1.2237755060195923, 0.5109038352966309, 1.2538129091262817, 0.46888303756713867, 1.3060334920883179, 0.37967485189437866, 1.2606565952301025, 0.40598341822624207, 0.3951030671596527, 1.2467869520187378, 0.6233850717544556, 0.1656215339899063, 0.13614852726459503, 0.28460532426834106, 0.018888752907514572, 0.0, 0.24573206901550293, 0.2877170443534851, 0.23554985225200653, 0.44276851415634155, 0.30130091309547424, 0.18947185575962067, 0.3219829797744751, 0.2654794156551361, 0.1766289621591568, 0.1080404669046402, 0.1782277673482895, 0.22058969736099243, 0.09556721895933151, 0.06671777367591858, 0.01442145835608244, 0.017150629311800003, 0.0636756643652916, 0.03249607980251312, 0.23955893516540527, 0.0, 0.22942227125167847, 0.0, 0.0, 0.0, 0.0, 0.13543494045734406, 0.29687079787254333, 0.21619564294815063, 0.04818578436970711, 0.22868314385414124, 0.0, 0.0, 0.021449433639645576, 0.1855085790157318, 0.04115002229809761, 0.00941805262118578, 0.0, 0.0, 0.0, 0.0, 0.04106453061103821, 0.030369965359568596, 0.0012961089378222823, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04285118728876114, 0.0, 0.0, 0.007405317388474941, 0.01730974018573761, 0.0, 0.014051085337996483, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05254270136356354, 0.016258375719189644, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011701466515660286, 0.0, 0.0698917880654335, 0.0, 0.093856081366539, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.10042271763086319, 0.0, 0.053767379373311996, 0.10876955091953278, 0.055535368621349335, 0.0, 0.0, 0.15036767721176147, 0.10424938052892685, 0.08839128911495209, 0.04984283074736595, 0.0022388319484889507, 0.021644210442900658, 0.019823456183075905, 0.1365942358970642, 0.06143598258495331, 0.0, 0.0, 0.0, 0.0, 0.05183979123830795, 0.09354117512702942, 0.0, 0.0, 0.06835965812206268, 0.0, 0.09515593945980072, 0.10141435265541077, 0.040501669049263, 0.0, 0.0, 0.0, 0.0, 0.0, 0.12360330671072006, 0.0, 0.015276777558028698, 0.0, 0.0, 0.011393187567591667, 0.13078917562961578, 0.055833764374256134, 0.1399064064025879, 0.03909439221024513, 0.061874423176050186, 0.0, 0.021699849516153336, 0.06598397344350815, 0.0, 0.0, 0.0055130827240645885, 0.001627921825274825, 0.0, 0.0, 0.0, 0.060300007462501526, 0.13210973143577576, 0.0, 0.0], [0.01570904813706875, 0.18019799888134003, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03722064197063446, 0.0, 0.0, 0.0, 0.12399379163980484, 0.15733614563941956, 0.119258351624012, 0.033540114760398865, 0.0, 0.0, 0.16954122483730316, 0.38633114099502563, 0.20087671279907227, 0.0640689954161644, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.023950181901454926, 0.0, 0.14165596663951874, 0.09692613035440445, 0.0008889152086339891, 0.051904138177633286, 0.0, 0.04753023013472557, 0.030127087607979774, 0.0, 0.0, 0.0, 0.0015659977216273546, 0.0, 0.0, 0.01557638868689537, 0.0, 0.0, 0.0, 0.006611572578549385, 0.0, 0.0, 0.012567732483148575, 0.0, 0.0037233824841678143, 0.0, 0.0, 0.027241138741374016, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13805589079856873, 0.0, 0.0, 0.033142998814582825, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.137823686003685, 0.31722718477249146, 0.08851319551467896, 0.13285274803638458, 0.19519703090190887, 0.08013936132192612, 0.06534452736377716, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.07325178384780884, 0.0, 0.0, 0.10865844786167145, 0.020165961235761642, 0.0, 0.03257347643375397, 0.0, 0.01941812038421631, 0.0, 0.0, 0.13569214940071106, 0.14605195820331573, 0.27461984753608704, 0.13065600395202637, 0.34742748737335205, 0.19115062057971954, 0.08115249127149582, 0.3560376465320587, 0.4927038550376892, 0.6525251269340515, 1.027587890625, 0.8771677613258362, 0.6273125410079956, 0.705075740814209, 0.22231750190258026, 0.09316293150186539, 0.16037945449352264, 0.22939343750476837, 0.5838661193847656, 0.25435671210289, 0.07320109754800797, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024495016783475876, 0.0, 0.0, 0.0, 0.0, 0.0018762083491310477, 0.0014095649821683764, 0.07493244111537933, 0.1078256294131279, 0.07332801818847656, 0.0, 0.0, 0.0, 0.12726731598377228, 0.019817283377051353, 0.0, 0.0, 0.27626341581344604, 0.3700346052646637, 0.6531872153282166, 0.41182199120521545, 0.2877456545829773, 0.0, 0.0, 0.0, 0.0, 0.21442994475364685, 0.1336415410041809, 0.1949114054441452, 0.06712313741445541, 0.18640680611133575, 0.418546199798584, 0.23712483048439026, 0.21781843900680542, 0.2850160002708435, 0.24029092490673065, 0.16525903344154358, 0.009801208972930908, 0.046568650752305984, 0.0, 0.18010209500789642, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05047690123319626, 0.18274478614330292, 0.4560104012489319, 0.4294913113117218, 0.6427329182624817, 0.9732319116592407, 1.0745681524276733, 1.0740891695022583, 0.8247576951980591, 0.34122684597969055, 0.053984519094228745, 0.016267044469714165, 0.0, 0.13872355222702026, 0.14234231412410736, 0.2914596199989319, 0.19150394201278687, 0.018844665959477425, 0.08864299952983856, 0.06857465952634811, 0.22371824085712433, 0.04220304265618324, 0.07265565544366837, 0.1080329418182373, 0.39102110266685486, 0.508126974105835, 0.26396605372428894, 0.21808074414730072, 0.14234252274036407, 0.19695471227169037, 0.14315561950206757, 0.016089508309960365, 0.01889265514910221, 0.09673024713993073, 0.002313177566975355, 0.002313177566975355], [0.4342167377471924, 0.8915908932685852, 1.3134005069732666, 0.8213129639625549, 1.5292043685913086, 1.432985544204712, 0.8271937370300293, 1.0024735927581787, 0.7657200694084167, 0.4447535574436188, 0.49844497442245483, 0.1253267079591751, 0.26348260045051575, 0.3998444974422455, 0.325586199760437, 0.297211229801178, 0.2780328691005707, 0.22405961155891418, 0.19152416288852692, 0.2761378288269043, 0.2762673795223236, 0.2742213308811188, 0.2540160119533539, 0.17474235594272614, 0.03485570102930069, 0.0, 0.03431552276015282, 0.01891409046947956, 0.012994270771741867, 0.012427768670022488, 0.054383546113967896, 0.04952843487262726, 0.06396088749170303, 0.0880930945277214, 0.0, 0.0, 0.0, 0.0, 0.012345288880169392, 0.007639724761247635, 0.0, 0.05338989198207855, 0.06042039394378662, 0.07290109992027283, 0.14162006974220276, 0.08427298069000244, 0.04163127392530441, 0.08852607011795044, 0.025511234998703003, 0.0, 0.005857549142092466, 0.0, 0.0, 0.0, 0.0, 0.004330964293330908, 0.005650898441672325, 0.0, 0.005588718689978123, 0.0, 0.020183224231004715, 0.0, 0.0, 0.014740275219082832, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008426611311733723, 0.0034173799213021994, 0.08371810615062714, 0.044906117022037506, 0.0, 0.0, 0.03344348073005676, 0.07949075847864151, 0.0, 0.0, 0.04906715080142021, 0.0, 0.1874890923500061, 0.0, 0.04118972644209862, 0.0, 0.0, 0.015989406034350395, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05604558065533638, 0.026663193479180336, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.037027355283498764, 0.0, 0.0, 0.0, 0.06199157238006592, 0.24611271917819977, 0.1677800565958023, 0.12186224013566971, 0.03562799096107483, 0.0, 0.0, 0.0, 0.05837435647845268, 0.0, 0.0037066969089210033, 0.0, 0.05232195556163788, 0.16437818109989166, 0.0, 0.0, 0.0, 0.0, 0.008886526338756084, 0.0, 0.0, 0.0, 0.0, 0.032881878316402435, 0.01744488626718521, 0.0, 0.0, 0.0, 0.0, 0.014706331305205822, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005209986120462418, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06861556321382523, 0.0, 0.0, 0.0, 0.006404137704521418, 0.0010469950502738357, 0.0, 0.0, 0.0, 0.0, 0.015558013692498207, 0.28598591685295105, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04222015291452408, 0.03017711453139782, 0.032971009612083435, 0.0, 0.0, 0.0, 0.0, 0.0025347392074763775, 0.0, 0.0, 0.0, 0.0, 0.16050192713737488, 0.18889015913009644, 0.1266663521528244, 0.061095502227544785, 0.037585191428661346, 0.0, 0.005835223477333784, 0.08586582541465759, 0.0687798261642456, 0.04485870152711868, 0.0, 0.03620266169309616, 0.023759718984365463, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.2054184079170227, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007911489345133305, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2393074780702591, 0.05133414268493652, 0.02572520449757576, 0.015178865753114223, 0.003147728741168976, 0.0, 0.0, 0.229232057929039, 0.0, 0.0, 0.0, 0.013847455382347107, 0.0, 0.015277111902832985, 0.0, 0.0, 0.0, 0.0, 0.011820834130048752, 0.0, 0.0, 0.0, 0.0045986054465174675, 0.0, 0.014849428087472916, 0.0, 0.014013925567269325, 0.0585077702999115, 0.05335588753223419, 0.056038226932287216, 0.051480863243341446, 0.010314223356544971, 0.004258695524185896, 0.016707798466086388, 0.055093564093112946, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04684501886367798, 0.0462772510945797, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0002624223125167191, 0.07215461134910583, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03611008822917938, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015633169561624527, 0.0, 0.0, 0.0, 0.0, 0.00017719804600346833, 0.0, 0.022690432146191597, 0.0, 0.0, 0.02180378884077072, 0.2450222223997116, 0.043027009814977646, 0.0567888543009758, 0.05836724489927292, 1.879791021347046, 0.03562738373875618, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00899293553084135, 0.012786355800926685, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0011102918069809675, 0.0, 0.026050427928566933, 0.0, 0.0, 0.0, 0.0, 0.0041466145776212215, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09408389776945114, 0.2250736653804779, 0.08673116564750671, 0.08148640394210815, 0.10868457704782486, 0.03877178952097893, 0.045580051839351654, 0.0, 0.0, 0.035919949412345886, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03858104720711708, 0.0, 0.0, 0.0, 0.0, 0.014364317990839481, 0.0, 0.0, 0.027486363425850868, 0.0, 0.0, 0.0, 0.0, 0.02350183203816414, 0.08198878914117813, 1.6005374193191528, 0.07774823158979416, 0.0, 0.0, 0.0, 0.0, 0.015404848381876945, 0.0, 0.0, 0.02547413669526577, 0.0, 0.01793474704027176, 0.0, 0.01464808639138937, 0.007901577278971672, 0.0, 0.031631141901016235, 0.01973111554980278, 0.007800951600074768, 0.07605905085802078, 0.10447262972593307, 0.10200071334838867, 0.07452534139156342, 0.06705451756715775, 0.0, 0.0, 0.0, 0.040017019957304, 0.0, 0.0, 0.0003946128999814391, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01624198444187641, 0.056211382150650024, 0.0730651468038559, 1.62269127368927, 0.07613889873027802, 0.06281533092260361, 0.002610699273645878, 0.0, 0.004171636886894703, 0.006989992223680019, 0.008356615900993347, 0.04684397578239441, 0.008662830106914043, 0.04471609741449356, 0.0042561693117022514, 0.0, 0.0, 0.0, 0.0, 0.0, 0.017869146540760994, 0.0, 0.0, 0.01074828952550888, 0.009285391308367252, 0.0, 0.0]]]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })"
@@ -2866,17 +5139,17 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 364
+          "height": 285
         },
         "id": "KDyIh9Lu3nz6",
-        "outputId": "a5ce4e56-1271-4276-9ca8-d429c09a9b44"
+        "outputId": "d44a7e5b-72c3-4fe8-97f7-be0fa415d79d"
       },
       "source": [
         "# Factorize the activations of only the first layer\n",
         "nmf_2 = output.run_nmf(n_components=10, from_layer=0, to_layer=1)\n",
         "nmf_2.explore()"
       ],
-      "execution_count": 160,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "display_data",
@@ -2971,7 +5244,7 @@
               "\n",
               "         requirejs(['basic', 'ecco'], function(basic, ecco){\n",
               "            const viz_id = basic.init()\n",
-              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[2.248868465423584, 0.19914190471172333, 0.05428381264209747, 0.06481804698705673, 0.0, 0.028632735833525658, 0.0, 0.0, 0.0, 0.1135987788438797, 0.00975265447050333, 0.02117617428302765, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0012453128583729267, 0.0, 0.0, 0.0, 0.0, 0.011928820982575417, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4133411645889282, 0.10889987647533417, 0.05317757651209831, 0.0, 0.009935258887708187, 0.0, 0.0, 0.0, 0.0, 0.025801626965403557, 0.018229112029075623, 0.0, 0.0, 0.0, 0.05513877049088478, 0.02964027039706707, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010058587417006493, 0.002356685698032379, 0.0, 0.0, 0.003757926169782877, 0.0, 0.0, 0.013391803950071335, 0.0, 0.0, 0.0, 0.02574501372873783, 0.022485928609967232, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06794992089271545, 0.0, 0.0818110927939415, 0.022252429276704788, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.029334671795368195, 0.08758559823036194, 0.00572799751535058, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.07201056182384491, 0.025250790640711784, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04639671370387077, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.042518068104982376, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0262862928211689, 0.0, 0.0, 0.0, 0.0443127416074276, 0.0, 0.013353399932384491, 0.0, 0.0, 0.0, 0.0, 0.11525154113769531, 0.0, 0.0, 0.025279376655817032, 0.0, 0.0, 0.0061400169506669044, 0.0, 0.0, 0.006935090757906437, 0.0002991606015712023, 0.044973284006118774, 0.01681588403880596, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04211759194731712, 0.0, 0.0, 0.034423161298036575, 0.0, 0.0, 0.01597008667886257, 0.4151197671890259, 0.0638761818408966, 0.0, 0.005009301006793976, 0.04191993549466133, 0.0, 0.0, 0.0, 0.0, 0.0726633220911026, 0.018532266840338707, 0.0008103119325824082, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027127815410494804, 0.0, 0.0, 0.0, 0.05861883983016014, 0.020688099786639214, 0.0, 0.09793952107429504, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01474451832473278, 0.0, 0.0, 0.055837810039520264, 0.015112402848899364, 0.0, 0.0, 0.0, 0.0, 0.0, 0.034561123698949814, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0279689934104681, 0.0027193333953619003, 0.0, 0.0, 0.0, 0.18219146132469177, 0.0, 0.07647842913866043, 0.0, 0.0, 0.0, 0.07573604583740234, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0076803648844361305, 0.008270356804132462, 0.03440992534160614, 0.0, 0.052424218505620956, 0.2854568064212799, 0.045262690633535385, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13681583106517792, 0.0, 0.0, 0.033780861645936966, 0.0, 0.0826205313205719, 0.0, 0.0286492221057415, 0.146817147731781, 0.03868834674358368, 0.0, 0.011709372512996197, 0.0, 0.0, 0.007665790151804686, 0.054988499730825424, 1.7513008117675781, 0.3900904953479767, 1.2240465879440308, 0.07469595968723297, 0.037167467176914215, 0.36439502239227295, 0.028364896774291992, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09270750731229782, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02485591173171997, 0.009974407032132149, 0.07524828612804413, 0.05290497839450836, 0.0, 0.0, 0.0, 0.023929879069328308, 0.0, 0.02977592684328556, 0.02476789616048336, 0.0, 0.03406411409378052, 0.08438251167535782, 0.0, 0.04742417111992836, 0.04560296609997749, 0.0, 0.0929894894361496, 0.0, 0.0, 0.0, 0.0, 0.10598404705524445, 0.005902727600187063, 0.0, 0.11704361438751221, 0.0, 0.0, 0.006399913225322962, 0.0, 0.01430473942309618, 0.3000241816043854, 0.004355287179350853, 0.0, 0.04635230079293251, 0.0, 0.0, 0.018482334911823273, 0.06402808427810669, 1.8049105405807495, 0.25471749901771545, 1.1695902347564697, 0.15151184797286987, 0.0, 0.025145525112748146, 0.16080762445926666, 0.08070383965969086, 0.0, 0.025220949202775955, 0.056410256773233414, 0.0, 0.027118312194943428, 0.09021039307117462, 0.2096295803785324, 0.030800288543105125, 0.25382715463638306, 0.022239601239562035, 0.0, 0.041303545236587524, 0.0, 0.022249408066272736, 0.0, 0.0, 0.017198333516716957, 0.0065716528333723545, 0.34508371353149414, 0.0, 0.03215719759464264, 0.021267686039209366, 0.0016803308390080929, 0.010830266401171684, 0.0, 0.09733086079359055, 0.04161658138036728, 0.0, 0.22505724430084229, 0.01914031058549881, 0.0695619061589241, 0.13509276509284973, 0.0, 0.0, 0.010339094325900078, 0.0, 0.0, 0.10563510656356812, 0.08514310419559479, 0.0, 0.11306536197662354, 0.10389241576194763, 0.035351209342479706, 0.003734017489477992, 0.04952318221330643, 0.0, 0.0958920568227768, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08113716542720795, 0.0, 0.0, 0.13901226222515106, 0.11456365138292313, 0.06997517496347427, 0.0, 0.0, 0.0, 0.020334850996732712, 0.06587518751621246, 0.0, 0.1016768217086792, 0.0, 0.0, 0.0, 0.0, 0.03650691732764244, 0.0, 0.0, 0.0, 0.01760750450193882, 0.023310687392950058, 0.0, 0.06533803790807724, 0.0, 0.0, 0.06081472709774971, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.040095504373311996, 0.0, 0.05007701367139816, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15650539100170135, 0.0, 0.02628341317176819, 0.0, 0.0, 0.0, 0.028518179431557655, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0399492084980011, 0.10755670070648193, 0.0, 0.21080447733402252, 0.0, 0.0, 0.0, 0.0], [0.00041871145367622375, 0.0, 0.0, 0.012646561488509178, 0.0, 0.06000348925590515, 0.19136697053909302, 0.19829361140727997, 0.19290108978748322, 0.32584744691848755, 0.3355977535247803, 0.17205104231834412, 0.20373207330703735, 0.31894731521606445, 0.10358444601297379, 0.25039148330688477, 0.3078889548778534, 0.3692091405391693, 0.338410347700119, 0.2874259948730469, 0.3127255439758301, 0.13004471361637115, 0.3079131245613098, 0.3443697690963745, 0.29472044110298157, 0.31263473629951477, 0.3384969234466553, 0.36100631952285767, 0.37484729290008545, 0.4467034637928009, 0.28595274686813354, 0.4073711633682251, 0.4422752857208252, 0.30242884159088135, 0.3272371292114258, 0.09685593843460083, 0.313404381275177, 0.18020765483379364, 0.39530614018440247, 0.31742531061172485, 0.27868759632110596, 0.33417245745658875, 0.40023961663246155, 0.4236425757408142, 0.41367027163505554, 0.3678438067436218, 0.3917253613471985, 0.2990340292453766, 0.3033410906791687, 0.3259538412094116, 0.3103844225406647, 0.3601021468639374, 0.20153792202472687, 0.21778517961502075, 0.3465045392513275, 0.31007662415504456, 0.29752078652381897, 0.3677709698677063, 0.262849897146225, 0.3456979990005493, 0.26631999015808105, 0.3454838693141937, 0.28900957107543945, 0.25844916701316833, 0.3024497926235199, 0.2950693666934967, 0.22887210547924042, 0.23265914618968964, 0.24892298877239227, 0.24433250725269318, 0.22618061304092407, 0.22765769064426422, 0.23927831649780273, 0.19445419311523438, 0.2822927236557007, 0.24279823899269104, 0.2626054286956787, 0.3356437087059021, 0.1471998542547226, 0.1945437490940094, 0.24893847107887268, 0.2521305978298187, 0.23541389405727386, 0.18749456107616425, 0.1873680204153061, 0.15583078563213348, 0.027951110154390335, 0.1745973825454712, 0.18815948069095612, 0.2151569277048111, 0.13926948606967926, 0.16441170871257782, 0.14642715454101562, 0.0, 0.10672581195831299, 0.0007901712087914348, 0.14015425741672516, 0.16024427115917206, 0.13830409944057465, 0.09902438521385193, 0.16896507143974304, 0.07793718576431274, 0.07285941392183304, 0.08368251472711563, 0.13540253043174744, 0.1282726377248764, 0.1217690110206604, 0.10164739191532135, 0.08197576552629471, 0.09318993240594864, 0.04302524775266647, 0.13610415160655975, 0.1312970221042633, 0.05992159992456436, 0.12413027882575989, 0.07085362076759338, 0.040206242352724075, 0.006579373497515917, 0.06639149785041809, 0.021707676351070404, 0.06555947661399841, 0.06735258549451828, 0.0, 0.014701521955430508, 0.04089716821908951, 0.05395623669028282, 0.015284382738173008, 0.0, 0.03395001217722893, 0.013085373677313328, 0.06697739660739899, 0.05440540984272957, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007338551338762045, 0.0, 0.0, 0.0, 0.0, 0.007985346019268036, 0.0, 0.022761503234505653, 0.0, 0.0, 0.0, 0.0, 0.025264162570238113, 0.0, 0.0, 0.0, 0.009280196391046047, 0.0, 0.0, 0.0017331117996945977, 0.0, 0.0, 0.0, 0.031354956328868866, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008301316760480404, 0.030961209908127785, 0.0, 0.0, 0.0, 0.004534855484962463, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.022221311926841736, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0003201410290785134, 0.0, 0.0, 0.0, 0.020402295514941216, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.000633910414762795, 0.0, 0.0, 0.0, 0.0, 0.02246970497071743, 0.0, 0.0], [0.0028668753802776337, 0.0, 0.0, 0.01210942305624485, 0.0, 0.0054697259329259396, 0.001091479673050344, 0.02762020193040371, 0.0021225407253950834, 0.005055196583271027, 0.021941473707556725, 0.02135508321225643, 0.00017849550931714475, 0.0, 0.7463119029998779, 0.06719506531953812, 0.03136724978685379, 0.017016900703310966, 0.01747375726699829, 0.007492806762456894, 0.020560139790177345, 0.74832683801651, 0.01567828468978405, 0.011534316465258598, 0.0, 0.022336887195706367, 0.003335826564580202, 0.0, 0.0870361477136612, 0.01043299213051796, 0.0, 0.0, 0.0017484213458374143, 0.0, 0.0, 0.007703251205384731, 0.0047086551785469055, 0.0, 0.0018715139012783766, 0.0, 0.0, 0.011609050445258617, 0.003382330294698477, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0048965150490403175, 0.0028824512846767902, 0.0, 0.0, 0.00672546960413456, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006700167898088694, 0.0, 0.004652409348636866, 0.0, 0.013145938515663147, 0.006124783307313919, 0.0017342694336548448, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013023787178099155, 0.0, 0.0, 0.0, 0.00032884906977415085, 0.0, 0.033160675317049026, 0.0, 0.6557504534721375, 0.020909877493977547, 0.010643890127539635, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0043077049776911736, 0.0, 0.04100041091442108, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0012540252646431327, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.036950308829545975, 0.0, 0.0, 0.4859772026538849, 0.034507375210523605, 0.01768415980041027, 0.0, 0.0, 0.06797552853822708, 0.0020136041566729546, 0.0026170467026531696, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0634278953075409, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006806603632867336, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13082222640514374, 0.022784538567066193, 0.0, 0.0, 0.027024269104003906, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006283660419285297, 0.10346530377864838, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05971863120794296, 0.0, 0.06412632018327713, 0.0, 0.00588566530495882, 0.0, 0.006568158511072397, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.5098298192024231, 0.0, 0.0, 0.0, 0.009175027720630169, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.337890088558197, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.35700979828834534, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007468526251614094, 0.0, 0.3708234429359436, 0.006196212023496628, 0.0048735253512859344, 0.0, 0.0025088535621762276, 0.0029957445804029703, 0.0, 0.0, 0.006077962461858988, 0.0014112564967945218, 0.010150894522666931, 0.002848707837983966, 0.011130238883197308, 0.0021154507994651794, 0.008086539804935455, 0.013184217736124992, 0.004353121388703585, 0.00016205618157982826, 0.4501263499259949, 0.01596415415406227, 0.005877703428268433, 0.4660699963569641, 0.0, 0.0, 0.012533744797110558, 0.019345758482813835, 0.001456145429983735, 0.0, 0.010307349264621735, 0.0, 0.0, 0.015545357950031757, 0.014555471017956734, 0.00020648635108955204, 0.0025126186665147543, 0.006105125416070223, 0.009776652790606022, 0.01491041574627161, 0.3773482143878937, 0.01957254856824875, 0.014133352786302567, 0.0011592836817726493, 0.0056995064951479435, 0.0024571388494223356, 0.0, 0.3591552674770355, 0.018588554114103317, 0.008506808429956436, 0.007843940518796444, 0.0047543891705572605, 0.0025813644751906395, 0.008118387311697006, 0.008236289024353027, 0.007015523500740528, 0.018952732905745506, 0.008127540349960327, 0.0, 0.006383451633155346, 0.00982784666121006, 0.4302990734577179, 0.03142481669783592, 0.0035710984375327826, 0.015965595841407776, 0.0, 0.44713306427001953, 0.008203227072954178, 0.018250105902552605, 0.4755527079105377, 0.014105027541518211, 0.010964712128043175, 0.007508584298193455, 0.021967262029647827, 0.009630429558455944, 0.005812155082821846, 0.3717343807220459, 0.010912163183093071, 0.014704978093504906, 0.015517494641244411, 0.012529121711850166, 0.019873028621077538, 0.0050098709762096405, 0.0, 0.005024988204240799, 0.009729930199682713, 0.01000702753663063, 0.42895376682281494, 0.026324771344661713, 0.004167990293353796, 0.01868537627160549, 0.008663028478622437, 0.0047576576471328735, 0.408733069896698, 0.015893220901489258, 0.005398245062679052, 0.005142273847013712, 0.0071443114429712296, 0.0041272458620369434, 0.4401533305644989, 0.02184584178030491, 0.0, 0.010631585493683815, 0.0, 0.0026335744187235832, 0.0016526394756510854, 0.0009178416221402586, 0.0, 0.0029612253420054913, 0.003870453452691436, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0070703886449337006, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015735018998384476, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4276816248893738, 0.0, 0.0, 0.0, 0.4255821108818054, 0.003373904386535287, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.00047063862439244986, 0.0, 0.0, 0.0, 0.0, 0.0, 0.6402985453605652, 0.4441607594490051, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013570137089118361, 0.0, 0.0, 0.03984600305557251, 0.0, 0.06877095252275467, 0.0, 0.05794937536120415, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00861564464867115, 0.0, 0.0, 0.0, 0.0, 0.0921441838145256, 0.02573600970208645, 0.0, 0.0, 0.0, 0.0, 4.722837184090167e-05, 0.0, 0.0, 0.040404628962278366, 0.004342230036854744, 0.030141130089759827, 0.008948896080255508, 0.6697588562965393, 0.41917943954467773, 0.0023781699128448963, 0.009725457057356834, 0.0939679890871048, 0.0, 0.0641588419675827, 0.0, 0.09119021892547607, 0.0, 0.0, 0.0, 0.0, 0.0021152524277567863, 0.08719512820243835, 0.0, 0.09380953758955002, 0.03168100491166115, 0.0, 0.10690872371196747, 0.11244812607765198, 0.15727253258228302, 0.0, 0.024986248463392258, 0.03319444879889488, 0.0, 0.0, 0.09501966834068298, 0.0, 0.0, 0.0017877949867397547, 0.033073604106903076, 0.008644594810903072, 0.022121887654066086, 0.00397608382627368, 0.01593095064163208, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005964093375951052, 0.0, 0.6569175720214844, 0.4187568426132202, 0.0, 0.0, 0.006053078919649124, 0.00805282685905695, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01749865896999836, 0.003606093116104603, 0.0, 0.0, 0.020641962066292763, 0.03879622370004654, 0.0, 0.025803813710808754, 0.0, 0.0038696567062288523, 0.0, 0.0, 0.012224833481013775, 0.005507431458681822, 0.0, 0.016105974093079567, 0.004794039763510227, 0.010966354981064796, 0.005096706096082926, 0.03324216604232788, 0.0, 0.04174065962433815, 0.013399647548794746, 0.0, 0.0044713094830513, 0.009786510840058327, 0.0, 0.040126699954271317, 0.025348078459501266, 0.014399409294128418, 0.0, 0.024620411917567253, 0.0, 0.0, 0.030243882909417152, 0.0009002672741189599, 0.04087049514055252, 0.0, 0.0, 0.0, 0.008951445110142231, 0.006553942337632179, 0.0, 0.0, 0.01343921385705471, 0.004083475563675165, 0.0, 0.6534117460250854, 0.4206988215446472, 0.022226758301258087, 0.005910049192607403, 0.011937577277421951, 0.010312825441360474, 0.0, 0.0, 0.024198167026042938, 0.0, 0.010962333530187607, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0026859089266508818, 0.6486964821815491, 0.4239378571510315, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008173448033630848, 0.0, 0.01211599726229906, 0.0, 0.0620742067694664, 0.0, 0.0014046302530914545, 0.024924086406826973, 0.01934189908206463, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08731494098901749, 0.0, 0.0, 0.0, 0.018420590087771416, 0.6521138548851013, 0.6521138548851013], [0.0, 0.016406912356615067, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005331495311111212, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01534871943295002, 0.0, 0.0, 0.010426369495689869, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013888145331293344, 0.0, 0.03258073329925537, 0.04567384719848633, 0.03013216145336628, 0.04437919706106186, 0.053942807018756866, 0.04163838177919388, 0.015979360789060593, 0.07204392552375793, 0.04485661908984184, 0.044134076684713364, 0.033053502440452576, 0.0, 0.02607300505042076, 0.058770086616277695, 0.0, 0.042835772037506104, 0.0602232851088047, 0.08192112296819687, 0.1306842714548111, 0.07928823679685593, 0.10058683156967163, 0.13838380575180054, 0.0, 0.056323904544115067, 0.15331938862800598, 0.14043666422367096, 0.12603111565113068, 0.11849420517683029, 0.17058199644088745, 0.15137317776679993, 0.13820047676563263, 0.06487852334976196, 0.16768990457057953, 0.2114015817642212, 0.0, 0.1845807582139969, 0.1553357094526291, 0.09632277488708496, 0.1118985265493393, 0.14092396199703217, 0.20437397062778473, 0.25991156697273254, 0.20816145837306976, 0.22262118756771088, 0.25889554619789124, 0.07267080992460251, 0.15188945829868317, 0.27477601170539856, 0.2824959456920624, 0.2395607829093933, 0.2694240212440491, 0.20560024678707123, 0.14761792123317719, 0.18171383440494537, 0.04086076095700264, 0.29289892315864563, 0.28090885281562805, 0.183493971824646, 0.30835628509521484, 0.33094149827957153, 0.1959366798400879, 0.2500540018081665, 0.2415025681257248, 0.2463310956954956, 0.36247095465660095, 0.26991966366767883, 0.29595816135406494, 0.225810706615448, 0.29331958293914795, 0.3206290602684021, 0.3158552944660187, 0.3095483183860779, 0.4085460305213928, 0.2617281973361969, 0.29549044370651245, 0.34343209862709045, 0.33809828758239746, 0.29751062393188477, 0.22722575068473816, 0.287837952375412, 0.24152010679244995, 0.34429997205734253, 0.3396172821521759, 0.309429407119751, 0.24982154369354248, 0.26831313967704773, 0.3526242971420288, 0.3705810010433197, 0.42606908082962036, 0.3676905035972595, 0.25799399614334106, 0.32832521200180054, 0.26723697781562805, 0.35533708333969116, 0.31047502160072327, 0.4302006661891937, 0.06577018648386002, 0.4076661765575409, 0.3446729779243469, 0.41282737255096436, 0.4732183814048767, 0.3120552897453308, 0.34563183784484863, 0.3646509051322937, 0.4108869135379791, 0.17009352147579193, 0.2437814474105835, 0.41771841049194336, 0.3363949656486511, 0.3195499777793884, 0.34303000569343567, 0.40726521611213684, 0.3893751800060272, 0.32272279262542725, 0.3323122262954712, 0.34517741203308105, 0.3978537321090698, 0.45076242089271545, 0.5082765817642212, 0.41817283630371094, 0.4250492453575134, 0.5357432961463928, 0.35771673917770386, 0.352815717458725, 0.17213556170463562, 0.3420962989330292, 0.17498618364334106, 0.24978263676166534, 0.4778253436088562, 0.39181584119796753, 0.4406587481498718, 0.39992445707321167, 0.5003752708435059, 0.3258812129497528, 0.3410593271255493, 0.4005270302295685, 0.45749422907829285, 0.36948758363723755, 0.5546650886535645, 0.09132939577102661, 0.4948355257511139, 0.4508521556854248, 0.4021439850330353, 0.35196948051452637, 0.4349493384361267, 0.3397790789604187, 0.4429900348186493, 0.27547165751457214, 0.35047459602355957, 0.3098337948322296, 0.4702368974685669, 0.4874511659145355, 0.41869309544563293, 0.3225730061531067, 0.3625560998916626, 0.333935022354126, 0.31436771154403687, 0.30122244358062744, 0.3206825256347656, 0.07810308039188385, 0.28667303919792175, 0.1457778513431549, 0.1457778513431549], [0.08865292370319366, 0.9266995787620544, 0.9985474348068237, 0.6672930121421814, 0.8694475293159485, 0.7148020267486572, 0.32620927691459656, 0.4291583299636841, 0.30200302600860596, 0.10967162996530533, 0.19236931204795837, 0.10445714741945267, 0.061616525053977966, 0.09938107430934906, 0.1103341281414032, 0.1838519275188446, 0.09326021373271942, 0.10525017231702805, 0.11288102716207504, 0.07133796811103821, 0.09913887828588486, 0.015181790105998516, 0.041108425706624985, 0.07932756841182709, 0.0, 0.03510633483529091, 0.012724579311907291, 0.0, 0.0, 0.0, 0.0, 0.0005823001265525818, 0.0, 0.04482191801071167, 0.0, 0.0, 0.0388583280146122, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004825077019631863, 0.0, 0.0, 0.0, 0.0, 0.0649779662489891, 0.057823698967695236, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024419162422418594, 0.0, 0.03169207274913788, 0.0, 0.03597426414489746, 0.021796822547912598, 0.0, 0.03545403480529785, 0.0, 0.0, 0.0, 0.015550674870610237, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008742989040911198, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.013306066393852234, 0.0, 0.0, 0.059182025492191315, 0.0, 0.040137238800525665, 0.0, 0.0, 0.13008230924606323, 0.0, 0.0, 0.0, 0.009771219454705715, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04126609116792679, 0.0, 0.0, 0.0, 0.0, 0.01901865378022194, 0.013724771328270435, 0.0, 0.00954233668744564, 0.0, 0.0, 0.019821511581540108, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0027689996641129255, 0.0, 0.022452449426054955, 0.04469846934080124, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.21992477774620056, 0.03691632300615311, 0.047923002392053604, 0.0, 0.0, 0.002085828222334385, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13418740034103394, 0.0, 0.005453112535178661, 0.0, 0.0, 0.0, 0.21230728924274445, 0.03583625331521034, 0.0, 0.0, 0.08052249252796173, 0.0, 0.03484482690691948, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.28226327896118164, 0.0, 0.0, 0.011551178991794586, 0.0, 0.0, 0.00679813651368022, 0.031549934297800064, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011288708075881004, 0.0, 0.0], [0.005701505579054356, 0.0, 0.004818009678274393, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014177058823406696, 0.0, 0.0007071232539601624, 0.0029353841673582792, 0.014036325737833977, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011077736504375935, 0.0, 0.0, 0.0, 0.0, 0.010382604785263538, 0.0, 0.0, 0.007424009498208761, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006767354905605316, 0.1062818244099617, 0.0077562713995575905, 0.0, 0.0, 0.0, 0.002597351325675845, 0.0, 0.03539007902145386, 0.01345741655677557, 0.004626333247870207, 0.0005645135533995926, 0.0048674787394702435, 0.0, 0.015541382133960724, 0.06663621962070465, 0.0, 0.0, 0.006044113077223301, 0.0011785554233938456, 0.0, 0.04012696444988251, 0.0, 0.0, 0.0, 0.01151345856487751, 0.004498753696680069, 0.0, 0.002843104302883148, 0.015107957646250725, 0.0, 0.0022486415691673756, 0.009120575152337551, 0.0, 0.0, 0.0, 1.2693525552749634, 0.018215063959360123, 0.0, 0.0, 0.004699725657701492, 0.012318117544054985, 0.0, 0.0, 0.020109230652451515, 0.006079548504203558, 0.0, 0.010832531377673149, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012597670778632164, 0.0037947415839880705, 0.0, 0.0, 0.0, 0.012318616732954979, 0.0006153009016998112, 0.010453993454575539, 0.0007653211941942573, 0.002540303161367774, 0.0005938527756370604, 0.01998170092701912, 0.0, 0.0, 0.032082706689834595, 0.024455305188894272, 0.0, 0.0, 0.015103409066796303, 0.04624611884355545, 0.051182717084884644, 0.0006445162580348551, 0.0, 0.0, 0.0, 0.0, 0.011483577080070972, 0.00037478344165720046, 0.018788261339068413, 0.005296229850500822, 0.08302217721939087, 0.0, 0.019949328154325485, 0.0, 0.018439294770359993, 0.02395068295300007, 0.0, 0.0, 0.0, 0.0, 0.0, 0.040807195007801056, 0.0, 0.01250394806265831, 0.0, 1.3374048471450806, 0.0, 0.009432153776288033, 0.0, 0.0, 0.006083035841584206, 0.043190356343984604, 0.0, 0.0, 0.012134012766182423, 0.0, 0.010859540663659573, 0.0, 0.04025115817785263, 0.0, 0.0, 0.002558374311774969, 0.019975366070866585, 0.0010052856523543596, 0.010905474424362183, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08286722004413605, 0.0, 0.0, 0.0029686850029975176, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06797253340482712, 0.0020453915931284428, 0.01953650265932083, 0.0, 0.0, 0.0, 1.3653024435043335, 0.01099684089422226, 0.0, 0.0, 0.012370925396680832, 0.0, 0.0, 0.0, 0.021636996418237686, 0.010968931019306183, 0.024342279881238937, 0.0, 0.0, 0.024240080267190933, 0.0, 0.00046864323667250574, 0.11212392896413803, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0021434074733406305, 0.0021434074733406305], [0.0, 0.0, 0.0, 0.0, 0.07077760249376297, 0.0, 0.017565475776791573, 0.0, 0.0, 0.010997915640473366, 0.0, 0.0, 0.0, 0.011701192706823349, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.18038775026798248, 0.0, 0.22206099331378937, 0.05171402171254158, 0.010928039439022541, 0.0, 0.000962684687692672, 0.0, 0.0, 0.10311131924390793, 0.07141798734664917, 0.0, 0.0, 0.008242073468863964, 0.0, 0.032894909381866455, 0.024236416444182396, 0.003393925493583083, 0.0, 0.0, 0.0, 0.0, 0.0, 0.11099109798669815, 0.02394021674990654, 0.0, 0.06822206825017929, 0.00463190209120512, 0.0, 0.0, 0.0, 0.12852558493614197, 0.10908811539411545, 0.0, 0.01754271611571312, 0.0, 0.022028546780347824, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0065334150567650795, 0.0, 0.05767833814024925, 0.0, 0.0, 0.06925734877586365, 0.040388450026512146, 0.05720093846321106, 0.0, 0.006760943681001663, 0.06790607422590256, 0.013451721519231796, 0.4814146161079407, 0.19209428131580353, 0.018211496993899345, 0.0, 0.015762001276016235, 0.0668974295258522, 0.0, 0.0, 0.0, 0.0, 0.004102910868823528, 0.0, 0.0, 0.0, 0.009810371324419975, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011876720935106277, 0.006927261129021645, 0.0, 0.0, 0.0, 0.0, 0.02549050748348236, 0.01699378713965416, 0.1036188155412674, 0.009442067705094814, 0.12895692884922028, 0.5308208465576172, 0.027770059183239937, 0.02406461536884308, 0.0, 0.0062158918008208275, 0.0, 0.0, 0.05845329537987709, 0.02429250441491604, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02151881344616413, 0.014943907037377357, 0.05869563668966293, 0.017079344019293785, 0.0, 0.07261943072080612, 0.0974440798163414, 0.0, 0.05147620663046837, 0.10395360738039017, 0.00989570003002882, 0.18460382521152496, 0.0, 0.003813469782471657, 0.0, 0.013694839552044868, 0.0, 0.05128759145736694, 0.05678490921854973, 0.006080601830035448, 0.01384340412914753, 0.0, 0.0, 0.0, 0.034538302570581436, 0.0, 0.0, 0.02317056618630886, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08870217949151993, 0.0479695126414299, 0.0, 0.02802438661456108, 0.020010843873023987, 0.011206083931028843, 0.08787792921066284, 0.03879648074507713, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006172508466988802, 0.0, 0.41724327206611633, 0.09592866152524948, 0.0, 0.0, 0.0, 0.03301147744059563, 0.0, 0.015664564445614815, 0.0, 0.07730359584093094, 0.10693416744470596, 0.0, 0.0, 0.0334678515791893, 0.0, 0.0, 0.0, 0.0, 0.007836887612938881, 0.0, 0.0, 0.060871995985507965, 0.0, 0.12382224202156067, 0.015964942052960396, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00284476182423532, 0.011141198687255383, 0.043827276676893234, 0.0, 0.09548735618591309, 0.5107822418212891, 0.07960253208875656, 0.0, 0.0]]]})\n",
+              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[2.2488694190979004, 0.19914229214191437, 0.05428369343280792, 0.06481808423995972, 0.0, 0.028632814064621925, 0.0, 0.0, 0.0, 0.11359899491071701, 0.00975275132805109, 0.021176131442189217, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0012453527888283134, 0.0, 0.0, 0.0, 0.0, 0.011928863823413849, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4133412539958954, 0.10889999568462372, 0.0531776137650013, 0.0, 0.009935255162417889, 0.0, 0.0, 0.0, 0.0, 0.025801651179790497, 0.018229058012366295, 0.0, 0.0, 0.0, 0.05513877421617508, 0.0296403206884861, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010058572515845299, 0.002356691053137183, 0.0, 0.0, 0.0037579680792987347, 0.0, 0.0, 0.013391773216426373, 0.0, 0.0, 0.0, 0.02574501372873783, 0.022485880181193352, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06794994324445724, 0.0, 0.08181119710206985, 0.022252468392252922, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.029334671795368195, 0.08758561313152313, 0.005728004965931177, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.07201065123081207, 0.025250831618905067, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04639677330851555, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04251805320382118, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02628626860678196, 0.0, 0.0, 0.0, 0.04431267827749252, 0.0, 0.013353378511965275, 0.0, 0.0, 0.0, 0.0, 0.11525163799524307, 0.0, 0.0, 0.025279350578784943, 0.0, 0.0, 0.00613996759057045, 0.0, 0.0, 0.0069351037964224815, 0.0002991551300510764, 0.04497329890727997, 0.01681583933532238, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04211757704615593, 0.0, 0.0, 0.03442315012216568, 0.0, 0.0, 0.01597009226679802, 0.41512003540992737, 0.06387624889612198, 0.0, 0.005009294021874666, 0.041919928044080734, 0.0, 0.0, 0.0, 0.0, 0.0726633295416832, 0.018532240763306618, 0.0008103117579594254, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027127843350172043, 0.0, 0.0, 0.0, 0.05861890688538551, 0.020688079297542572, 0.0, 0.09793951362371445, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014744481071829796, 0.0, 0.0, 0.055837880820035934, 0.015112402848899364, 0.0, 0.0, 0.0, 0.0, 0.0, 0.034561123698949814, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027969015762209892, 0.002719320822507143, 0.0, 0.0, 0.0, 0.1821916699409485, 0.0, 0.07647852599620819, 0.0, 0.0, 0.0, 0.07573612779378891, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.007680268492549658, 0.008270356804132462, 0.03440959006547928, 0.0, 0.052423931658267975, 0.2854554057121277, 0.04526253044605255, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13681480288505554, 0.0, 0.0, 0.03378066420555115, 0.0, 0.08262018859386444, 0.0, 0.02864907868206501, 0.1468162089586258, 0.03868809714913368, 0.0, 0.01170927844941616, 0.0, 0.0, 0.007665751036256552, 0.05498819425702095, 1.751288890838623, 0.3900880515575409, 1.2240394353866577, 0.07469566911458969, 0.03716732934117317, 0.36439260840415955, 0.028364742174744606, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09270710498094559, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024855807423591614, 0.009974401444196701, 0.07524784654378891, 0.05290480703115463, 0.0, 0.0, 0.0, 0.02392970770597458, 0.0, 0.029775695875287056, 0.024767732247710228, 0.0, 0.034063905477523804, 0.0843820795416832, 0.0, 0.047423917800188065, 0.04560275003314018, 0.0, 0.092988982796669, 0.0, 0.0, 0.0, 0.0, 0.1059834361076355, 0.005902821663767099, 0.0, 0.11704286187887192, 0.0, 0.0, 0.006399882026016712, 0.0, 0.014304696582257748, 0.3000221848487854, 0.004355241544544697, 0.0, 0.04635203629732132, 0.0, 0.0, 0.018482208251953125, 0.06402775645256042, 1.8048983812332153, 0.2547157108783722, 1.1695822477340698, 0.15151090919971466, 0.0, 0.02514535002410412, 0.16080684959888458, 0.08070340007543564, 0.0, 0.02522076852619648, 0.05640990287065506, 0.0, 0.027118166908621788, 0.09021002054214478, 0.2096281349658966, 0.030800074338912964, 0.25382542610168457, 0.02223939821124077, 0.0, 0.0413033664226532, 0.0, 0.02224930189549923, 0.0, 0.0, 0.017198236659169197, 0.006571632344275713, 0.3450813293457031, 0.0, 0.0321570560336113, 0.0212674792855978, 0.0016803313046693802, 0.010830201208591461, 0.0, 0.09733013808727264, 0.04161633178591728, 0.0, 0.22505563497543335, 0.019140226766467094, 0.06956152617931366, 0.13509191572666168, 0.0, 0.0, 0.010338977910578251, 0.0, 0.0, 0.10563433915376663, 0.08514238893985748, 0.0, 0.11306464672088623, 0.10389173030853271, 0.0353509783744812, 0.003733984660357237, 0.04952282831072807, 0.0, 0.09589148312807083, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08113665878772736, 0.0, 0.0, 0.13901127874851227, 0.11456291377544403, 0.06997469812631607, 0.0, 0.0, 0.0, 0.02033466286957264, 0.06587465107440948, 0.0, 0.10167618095874786, 0.0, 0.0, 0.0, 0.0, 0.03650675714015961, 0.0, 0.0, 0.0, 0.01760740764439106, 0.023310450837016106, 0.0, 0.06533757597208023, 0.0, 0.0, 0.0608142651617527, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04009508341550827, 0.0, 0.0500766895711422, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1565043032169342, 0.0, 0.02628328837454319, 0.0, 0.0, 0.0, 0.028517980128526688, 0.0, 0.0, 0.0, 0.0, 0.0, 0.039948903024196625, 0.10755592584609985, 0.0, 0.21080318093299866, 0.0, 0.0, 0.0, 0.0], [0.000419020710978657, 0.0, 0.0, 0.012646435759961605, 0.0, 0.060003187507390976, 0.1913665235042572, 0.19829310476779938, 0.192900612950325, 0.3258463144302368, 0.33559688925743103, 0.1720505654811859, 0.20373155176639557, 0.31894659996032715, 0.10358438640832901, 0.2503904700279236, 0.3078881800174713, 0.3692081868648529, 0.3384094834327698, 0.28742510080337524, 0.31272459030151367, 0.13004420697689056, 0.30791211128234863, 0.3443688154220581, 0.29471975564956665, 0.31263357400894165, 0.33849605917930603, 0.36100533604621887, 0.37484651803970337, 0.44670215249061584, 0.285952091217041, 0.40736985206604004, 0.4422741234302521, 0.3024279773235321, 0.3272364139556885, 0.0968555212020874, 0.31340333819389343, 0.18020698428153992, 0.39530467987060547, 0.3174241781234741, 0.27868661284446716, 0.3341711461544037, 0.4002385139465332, 0.42364129424095154, 0.4136691391468048, 0.36784297227859497, 0.39172452688217163, 0.29903295636177063, 0.3033401072025299, 0.32595279812812805, 0.31038352847099304, 0.3601008951663971, 0.20153725147247314, 0.2177845537662506, 0.346503347158432, 0.3100757300853729, 0.29752013087272644, 0.3677698075771332, 0.26284903287887573, 0.34569698572158813, 0.2663191556930542, 0.3454829156398773, 0.289008766412735, 0.25844839215278625, 0.30244871973991394, 0.29506853222846985, 0.22887133061885834, 0.2326582819223404, 0.24892234802246094, 0.2443319857120514, 0.22617995738983154, 0.22765691578388214, 0.23927763104438782, 0.19445368647575378, 0.2822919487953186, 0.24279744923114777, 0.2626045048236847, 0.3356426954269409, 0.14719940721988678, 0.19454331696033478, 0.2489376664161682, 0.2521298825740814, 0.23541320860385895, 0.1874941736459732, 0.18736746907234192, 0.15583036839962006, 0.027951044961810112, 0.17459678649902344, 0.18815888464450836, 0.21515622735023499, 0.13926902413368225, 0.1644112914800644, 0.14642681181430817, 0.0, 0.10672537982463837, 0.0007900786004029214, 0.1401539444923401, 0.16024382412433624, 0.13830383121967316, 0.09902402758598328, 0.16896457970142365, 0.07793689519166946, 0.07285921275615692, 0.08368208259344101, 0.13540217280387878, 0.12827223539352417, 0.12176855653524399, 0.10164700448513031, 0.08197539299726486, 0.09318950027227402, 0.04302496835589409, 0.13610367476940155, 0.13129658997058868, 0.05992121994495392, 0.12412993609905243, 0.07085331529378891, 0.04020587354898453, 0.006579205393791199, 0.06639134883880615, 0.02170763909816742, 0.06555917859077454, 0.06735233217477798, 0.0, 0.014701339416205883, 0.04089704155921936, 0.05395601689815521, 0.015284311026334763, 0.0, 0.03394988551735878, 0.01308526936918497, 0.06697716563940048, 0.054405175149440765, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007338525261729956, 0.0, 0.0, 0.0, 0.0, 0.007985292002558708, 0.0, 0.022761382162570953, 0.0, 0.0, 0.0, 0.0, 0.02526407316327095, 0.0, 0.0, 0.0, 0.009280144236981869, 0.0, 0.0, 0.0017330569680780172, 0.0, 0.0, 0.0, 0.0313548669219017, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00830126740038395, 0.03096112608909607, 0.0, 0.0, 0.0, 0.0045348224230110645, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.02222120389342308, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0003201133222319186, 0.0, 0.0, 0.0, 0.020402194932103157, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0006338750827126205, 0.0, 0.0, 0.0, 0.0, 0.022469619289040565, 0.0, 0.0], [0.0028668642044067383, 0.0, 0.0, 0.012109460309147835, 0.0, 0.005469737108796835, 0.0010914664017036557, 0.027620233595371246, 0.002122532343491912, 0.005055221728980541, 0.02194151282310486, 0.021355152130126953, 0.00017847647541202605, 0.0, 0.7463138699531555, 0.06719524413347244, 0.031367331743240356, 0.017016896978020668, 0.01747378148138523, 0.007492830511182547, 0.020560195669531822, 0.748329222202301, 0.01567833684384823, 0.011534368619322777, 0.0, 0.0223369263112545, 0.003335797693580389, 0.0, 0.08703641593456268, 0.010433022864162922, 0.0, 0.0, 0.001748386537656188, 0.0, 0.0, 0.007703305687755346, 0.00470867520198226, 0.0, 0.0018715373007580638, 0.0, 0.0, 0.011609095148742199, 0.003382319351658225, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004896556492894888, 0.0028824456967413425, 0.0, 0.0, 0.006725498009473085, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006700211204588413, 0.0, 0.004652435891330242, 0.0, 0.013146042823791504, 0.0061248051933944225, 0.00173430354334414, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013023923384025693, 0.0, 0.0, 0.0, 0.0003288521256763488, 0.0, 0.033160772174596786, 0.0, 0.6557527780532837, 0.020909976214170456, 0.010643900372087955, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004307747818529606, 0.0, 0.04100058972835541, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0012540490133687854, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03695044666528702, 0.0, 0.0, 0.48597875237464905, 0.03450747951865196, 0.017684204503893852, 0.0, 0.0, 0.0679757297039032, 0.0020136176608502865, 0.0026170690543949604, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06342807412147522, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006806625053286552, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13082259893417358, 0.022784564644098282, 0.0, 0.0, 0.02702433615922928, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006283662281930447, 0.10346560180187225, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05971880629658699, 0.0, 0.06412657350301743, 0.0, 0.005885700695216656, 0.0, 0.006568163633346558, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.5098303556442261, 0.0, 0.0, 0.0, 0.009175040759146214, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3378904461860657, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.35701000690460205, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007468529976904392, 0.0, 0.3708236515522003, 0.006196197122335434, 0.004873547237366438, 0.0, 0.0025088530965149403, 0.0029957385268062353, 0.0, 0.0, 0.006077946629375219, 0.0014112470671534538, 0.010150883346796036, 0.0028486973606050014, 0.011130230501294136, 0.0021154582500457764, 0.008086549118161201, 0.013184246607124805, 0.00435310835018754, 0.0001620476396055892, 0.45012667775154114, 0.01596415601670742, 0.005877690855413675, 0.4660703241825104, 0.0, 0.0, 0.012533756904304028, 0.01934574916958809, 0.0014561425196006894, 0.0, 0.010307332500815392, 0.0, 0.0, 0.015545370057225227, 0.014555470086634159, 0.00020647664496209472, 0.00251262285746634, 0.00610513798892498, 0.009776655584573746, 0.014910419471561909, 0.37734851241111755, 0.019572550430893898, 0.014133361168205738, 0.001159279141575098, 0.005699488800019026, 0.002457124413922429, 0.0, 0.3591553568840027, 0.018588589504361153, 0.008506794460117817, 0.0078439237549901, 0.004754388704895973, 0.0025813558604568243, 0.008118391036987305, 0.008236306719481945, 0.00701551279053092, 0.018952738493680954, 0.008127548731863499, 0.0, 0.0063834539614617825, 0.009827842004597187, 0.4302992820739746, 0.03142484277486801, 0.0035711147356778383, 0.015965590253472328, 0.0, 0.4471333622932434, 0.00820324569940567, 0.0182501133531332, 0.47555315494537354, 0.014105028472840786, 0.010964730754494667, 0.0075085763819515705, 0.02196725830435753, 0.009630425833165646, 0.005812149494886398, 0.3717346787452698, 0.010912175290286541, 0.014704986475408077, 0.01551748625934124, 0.012529116123914719, 0.01987304538488388, 0.005009882152080536, 0.0, 0.005024968646466732, 0.009729921817779541, 0.010007034055888653, 0.42895379662513733, 0.026324793696403503, 0.0041679819114506245, 0.018685391172766685, 0.008662995882332325, 0.004757660441100597, 0.4087334871292114, 0.01589321531355381, 0.005398251581937075, 0.005142296198755503, 0.007144315168261528, 0.004127242136746645, 0.44015365839004517, 0.021845849230885506, 0.0, 0.010631588287651539, 0.0, 0.0026335730217397213, 0.0016526279505342245, 0.0009178203181363642, 0.0, 0.002961218822747469, 0.0038704373873770237, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007070369552820921, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015734991058707237, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.42768189311027527, 0.0, 0.0, 0.0, 0.42558208107948303, 0.0033738554921001196, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0004706517211161554, 0.0, 0.0, 0.0, 0.0, 0.0, 0.6403000354766846, 0.44416171312332153, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013570133596658707, 0.0, 0.0, 0.03984609991312027, 0.0, 0.06877115368843079, 0.0, 0.057949431240558624, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008615663275122643, 0.0, 0.0, 0.0, 0.0, 0.09214445948600769, 0.025736026465892792, 0.0, 0.0, 0.0, 0.0, 4.721791628981009e-05, 0.0, 0.0, 0.040404707193374634, 0.004342231433838606, 0.030141158029437065, 0.00894895475357771, 0.6697605848312378, 0.41918015480041504, 0.0023781864438205957, 0.00972544401884079, 0.09396820515394211, 0.0, 0.06415898352861404, 0.0, 0.0911903977394104, 0.0, 0.0, 0.0, 0.0, 0.0021152382250875235, 0.08719528466463089, 0.0, 0.09380972385406494, 0.031681083142757416, 0.0, 0.10690894722938538, 0.11244847625494003, 0.15727286040782928, 0.0, 0.02498629502952099, 0.03319452702999115, 0.0, 0.0, 0.0950198620557785, 0.0, 0.0, 0.0017878012731671333, 0.033073678612709045, 0.008644604124128819, 0.022121956571936607, 0.003976077772676945, 0.015930980443954468, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005964113399386406, 0.0, 0.6569194197654724, 0.41875767707824707, 0.0, 0.0, 0.006053089164197445, 0.008052842691540718, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.017498716711997986, 0.0036061001010239124, 0.0, 0.0, 0.020642003044486046, 0.03879629448056221, 0.0, 0.02580389380455017, 0.0, 0.0038696571718901396, 0.0, 0.0, 0.01222484651952982, 0.005507440771907568, 0.0, 0.01610598899424076, 0.004794054199010134, 0.01096637174487114, 0.005096717271953821, 0.03324226289987564, 0.0, 0.0417407862842083, 0.013399687595665455, 0.0, 0.0044713011011481285, 0.009786540642380714, 0.0, 0.040126778185367584, 0.025348125025629997, 0.014399423263967037, 0.0, 0.02462046593427658, 0.0, 0.0, 0.03024389035999775, 0.0009002688457258046, 0.040870536118745804, 0.0, 0.0, 0.0, 0.008951450698077679, 0.006553952116519213, 0.0, 0.0, 0.013439239002764225, 0.004083474166691303, 0.0, 0.6534132361412048, 0.4206995368003845, 0.022226806730031967, 0.005910041276365519, 0.011937599629163742, 0.010312844067811966, 0.0, 0.0, 0.024198206141591072, 0.0, 0.010962353087961674, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0026859212666749954, 0.6486977338790894, 0.4239387512207031, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008173464797437191, 0.0, 0.01211601123213768, 0.0, 0.06207435950636864, 0.0, 0.0014046214055269957, 0.024924134835600853, 0.019341975450515747, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0873151496052742, 0.0, 0.0, 0.0, 0.018420640379190445, 0.6521154046058655, 0.6521154046058655], [0.0, 0.016406835988163948, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005331524182111025, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015348711982369423, 0.0, 0.0, 0.01042636577039957, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0013888449175283313, 0.0, 0.03258053585886955, 0.04567381739616394, 0.03013201430439949, 0.044379111379384995, 0.05394263565540314, 0.04163830727338791, 0.015979371964931488, 0.07204392552375793, 0.04485663026571274, 0.04413400962948799, 0.033053334802389145, 0.0, 0.026072915643453598, 0.058769963681697845, 0.0, 0.04283561185002327, 0.060223113745450974, 0.0819210410118103, 0.13068407773971558, 0.07928816974163055, 0.10058660805225372, 0.13838355243206024, 0.0, 0.05632366985082626, 0.15331922471523285, 0.14043648540973663, 0.12603096663951874, 0.11849389970302582, 0.17058168351650238, 0.15137295424938202, 0.13820026814937592, 0.06487847864627838, 0.16768966615200043, 0.2114010453224182, 0.0, 0.18458059430122375, 0.1553354263305664, 0.09632270038127899, 0.11189835518598557, 0.140923872590065, 0.2043738067150116, 0.25991126894950867, 0.20816096663475037, 0.22262084484100342, 0.25889503955841064, 0.07267062366008759, 0.15188920497894287, 0.2747756242752075, 0.28249555826187134, 0.2395603358745575, 0.2694237232208252, 0.2055998295545578, 0.1476176679134369, 0.18171368539333344, 0.04086065664887428, 0.292898565530777, 0.2809082269668579, 0.18349379301071167, 0.30835583806037903, 0.33094125986099243, 0.19593650102615356, 0.25005364418029785, 0.24150221049785614, 0.24633073806762695, 0.3624705672264099, 0.2699190676212311, 0.29595786333084106, 0.22581031918525696, 0.2933189272880554, 0.32062873244285583, 0.3158547878265381, 0.30954769253730774, 0.40854552388191223, 0.26172783970832825, 0.29548993706703186, 0.343431681394577, 0.33809778094291687, 0.29750996828079224, 0.2272253930568695, 0.2878376245498657, 0.24151955544948578, 0.3442995250225067, 0.3396167457103729, 0.309428870677948, 0.249821275472641, 0.2683126926422119, 0.35262396931648254, 0.37058040499687195, 0.426068514585495, 0.3676900565624237, 0.25799360871315, 0.32832470536231995, 0.2672366797924042, 0.35533642768859863, 0.3104745149612427, 0.43019992113113403, 0.06576988101005554, 0.40766555070877075, 0.34467244148254395, 0.4128267467021942, 0.4732177257537842, 0.31205499172210693, 0.34563130140304565, 0.3646504580974579, 0.41088640689849854, 0.1700930893421173, 0.24378110468387604, 0.4177180528640747, 0.33639439940452576, 0.3195495009422302, 0.3430297076702118, 0.4072644114494324, 0.3893744647502899, 0.32272231578826904, 0.33231157064437866, 0.34517696499824524, 0.39785313606262207, 0.45076173543930054, 0.5082756876945496, 0.41817203164100647, 0.4250488579273224, 0.5357425808906555, 0.35771629214286804, 0.3528153598308563, 0.17213498055934906, 0.3420957028865814, 0.1749860644340515, 0.24978211522102356, 0.4778245985507965, 0.3918151259422302, 0.4406583607196808, 0.39992374181747437, 0.5003746747970581, 0.32588064670562744, 0.3410588204860687, 0.40052634477615356, 0.45749354362487793, 0.36948713660240173, 0.5546642541885376, 0.0913291722536087, 0.4948348104953766, 0.4508514404296875, 0.40214359760284424, 0.3519689738750458, 0.434948593378067, 0.33977872133255005, 0.44298937916755676, 0.2754710614681244, 0.35047417879104614, 0.309833288192749, 0.47023653984069824, 0.48745042085647583, 0.41869258880615234, 0.32257258892059326, 0.36255568265914917, 0.33393460512161255, 0.31436726450920105, 0.3012218475341797, 0.32068198919296265, 0.07810274511575699, 0.28667256236076355, 0.14577756822109222, 0.14577756822109222], [0.08865301311016083, 0.9267003536224365, 0.9985474944114685, 0.6672933101654053, 0.869447648525238, 0.7148025631904602, 0.32620933651924133, 0.4291585385799408, 0.3020034730434418, 0.10967160016298294, 0.19236938655376434, 0.10445715487003326, 0.061616525053977966, 0.09938105195760727, 0.11033423990011215, 0.18385227024555206, 0.09326009452342987, 0.10525025427341461, 0.11288115382194519, 0.07133805006742477, 0.099139004945755, 0.015181910246610641, 0.041108421981334686, 0.07932773232460022, 0.0, 0.03510640561580658, 0.012724521569907665, 0.0, 0.0, 0.0, 0.0, 0.0005822775419801474, 0.0, 0.04482195898890495, 0.0, 0.0, 0.03885841369628906, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004825068637728691, 0.0, 0.0, 0.0, 0.0, 0.06497804075479507, 0.05782371014356613, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.024419210851192474, 0.0, 0.03169215843081474, 0.0, 0.035974252969026566, 0.021796828135848045, 0.0, 0.03545406460762024, 0.0, 0.0, 0.0, 0.015550739131867886, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0087429853156209, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.013306070119142532, 0.0, 0.0, 0.05918212607502937, 0.0, 0.040137238800525665, 0.0, 0.0, 0.13008248805999756, 0.0, 0.0, 0.0, 0.009771255776286125, 0.0, 0.0, 0.0, 0.0, 0.0, 0.041266098618507385, 0.0, 0.0, 0.0, 0.0, 0.019018640741705894, 0.013724787160754204, 0.0, 0.009542297571897507, 0.0, 0.0, 0.01982150599360466, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0027689903508871794, 0.0, 0.022452462464571, 0.04469846561551094, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.21992486715316772, 0.0369163416326046, 0.047923047095537186, 0.0, 0.0, 0.0020858128555119038, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13418737053871155, 0.0, 0.005453118588775396, 0.0, 0.0, 0.0, 0.21230758726596832, 0.03583626076579094, 0.0, 0.0, 0.08052258938550949, 0.0, 0.034844834357500076, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.28226345777511597, 0.0, 0.0, 0.01155118178576231, 0.0, 0.0, 0.00679814163595438, 0.03154996037483215, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011288708075881004, 0.0, 0.0], [0.005701436661183834, 0.0, 0.004818052519112825, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014177115634083748, 0.0, 0.0007071315194480121, 0.002935337834060192, 0.014036296866834164, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01107776165008545, 0.0, 0.0, 0.0, 0.0, 0.010382593609392643, 0.0, 0.0, 0.007424010895192623, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006767348852008581, 0.10628184676170349, 0.007756287232041359, 0.0, 0.0, 0.0, 0.002597375540062785, 0.0, 0.03539006784558296, 0.013457421213388443, 0.004626349080353975, 0.0005645205383189023, 0.00486748805269599, 0.0, 0.01554141752421856, 0.06663628667593002, 0.0, 0.0, 0.006044149398803711, 0.001178566599264741, 0.0, 0.0401269905269146, 0.0, 0.0, 0.0, 0.011513435281813145, 0.004498762544244528, 0.0, 0.0028431075625121593, 0.015107940882444382, 0.0, 0.0022486334200948477, 0.009120549075305462, 0.0, 0.0, 0.0, 1.2693530321121216, 0.018215041607618332, 0.0, 0.0, 0.004699717741459608, 0.012318153865635395, 0.0, 0.0, 0.02010924555361271, 0.006079545710235834, 0.0, 0.010832535102963448, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012597702443599701, 0.0037947408854961395, 0.0, 0.0, 0.0, 0.012318613938987255, 0.0006153276190161705, 0.010454008355736732, 0.0007653021020814776, 0.0025403148028999567, 0.0005938553367741406, 0.01998172514140606, 0.0, 0.0, 0.03208274766802788, 0.024455364793539047, 0.0, 0.0, 0.015103388577699661, 0.04624611884355545, 0.05118277668952942, 0.0006444970495067537, 0.0, 0.0, 0.0, 0.0, 0.011483612470328808, 0.000374796858523041, 0.018788283690810204, 0.005296248011291027, 0.08302219212055206, 0.0, 0.019949350506067276, 0.0, 0.0184392761439085, 0.02395068109035492, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04080716893076897, 0.0, 0.012503921054303646, 0.0, 1.3374052047729492, 0.0, 0.009432070888578892, 0.0, 0.0, 0.006083046551793814, 0.04319033771753311, 0.0, 0.0, 0.012134024873375893, 0.0, 0.010859456844627857, 0.0, 0.04025113955140114, 0.0, 0.0, 0.0025583794340491295, 0.019975366070866585, 0.0010052724974229932, 0.010905461385846138, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08286721259355545, 0.0, 0.0, 0.002968670567497611, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06797255575656891, 0.0020453601609915495, 0.019536470994353294, 0.0, 0.0, 0.0, 1.3653031587600708, 0.010996823199093342, 0.0, 0.0, 0.01237086858600378, 0.0, 0.0, 0.0, 0.02163698337972164, 0.010968904942274094, 0.02434229664504528, 0.0, 0.0, 0.02424003928899765, 0.0, 0.00046855397522449493, 0.11212387681007385, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0021433925721794367, 0.0021433925721794367], [0.0, 0.0, 0.0, 0.0, 0.07077764719724655, 0.0, 0.017565453425049782, 0.0, 0.0, 0.010997901670634747, 0.0, 0.0, 0.0, 0.011701153591275215, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.18038782477378845, 0.0, 0.22206105291843414, 0.05171405151486397, 0.010927995666861534, 0.0, 0.0009626538376323879, 0.0, 0.0, 0.1031113937497139, 0.07141804695129395, 0.0, 0.0, 0.008242039941251278, 0.0, 0.03289490565657616, 0.024236425757408142, 0.0033939380664378405, 0.0, 0.0, 0.0, 0.0, 0.0, 0.11099125444889069, 0.023940254002809525, 0.0, 0.06822217255830765, 0.004631908144801855, 0.0, 0.0, 0.0, 0.12852583825588226, 0.10908836871385574, 0.0, 0.017542777583003044, 0.0, 0.022028591483831406, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006533388048410416, 0.0, 0.057678379118442535, 0.0, 0.0, 0.06925742328166962, 0.040388476103544235, 0.05720099061727524, 0.0, 0.006760940421372652, 0.0679062008857727, 0.013451727107167244, 0.48141488432884216, 0.19209446012973785, 0.018211472779512405, 0.0, 0.015761999413371086, 0.06689750403165817, 0.0, 0.0, 0.0, 0.0, 0.004102933686226606, 0.0, 0.0, 0.0, 0.009810375049710274, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011876762844622135, 0.006927254144102335, 0.0, 0.0, 0.0, 0.0, 0.025490526109933853, 0.016993850469589233, 0.10361892729997635, 0.00944206677377224, 0.1289571225643158, 0.5308212637901306, 0.02777007594704628, 0.0240646880120039, 0.0, 0.006215893197804689, 0.0, 0.0, 0.058453381061553955, 0.024292543530464172, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.021518854424357414, 0.014943944290280342, 0.05869573354721069, 0.017079409211874008, 0.0, 0.07261957228183746, 0.09744422137737274, 0.0, 0.051476262509822845, 0.1039537787437439, 0.009895700961351395, 0.1846040040254593, 0.0, 0.0038134681526571512, 0.0, 0.013694871217012405, 0.0, 0.05128767341375351, 0.05678500980138779, 0.006080617196857929, 0.013843436725437641, 0.0, 0.0, 0.0, 0.034538354724645615, 0.0, 0.0, 0.023170582950115204, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0887022539973259, 0.04796953871846199, 0.0, 0.02802440896630287, 0.020010866224765778, 0.011206088587641716, 0.08787810057401657, 0.0387965552508831, 0.0, 0.0, 0.0, 0.0, 0.0, 0.006172489374876022, 0.0, 0.4172435998916626, 0.09592874348163605, 0.0, 0.0, 0.0, 0.033011533319950104, 0.0, 0.015664556995034218, 0.0, 0.0773036852478981, 0.1069343313574791, 0.0, 0.0, 0.03346782550215721, 0.0, 0.0, 0.0, 0.0, 0.007836875505745411, 0.0, 0.0, 0.06087211146950722, 0.0, 0.12382232397794724, 0.015964947640895844, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0028447445947676897, 0.011141177266836166, 0.04382728412747383, 0.0, 0.0954875573515892, 0.5107825994491577, 0.07960262894630432, 0.0, 0.0]]]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })"
@@ -2991,17 +5264,17 @@
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 364
+          "height": 285
         },
         "id": "tjqnypNy3xFb",
-        "outputId": "14d99194-283c-4e78-bc1a-248885ec1d0b"
+        "outputId": "e2ad3ef5-4bca-4740-d61c-246ea828e20b"
       },
       "source": [
         "# Factorize the activations of layers from 1 to 5\n",
         "nmf_3 = output.run_nmf(n_components=10, from_layer=0, to_layer=2)\n",
         "nmf_3.explore()"
       ],
-      "execution_count": 162,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "display_data",
@@ -3096,7 +5369,7 @@
               "\n",
               "         requirejs(['basic', 'ecco'], function(basic, ecco){\n",
               "            const viz_id = basic.init()\n",
-              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005007313564419746, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09339625388383865, 0.0, 0.0, 0.01080173160880804, 0.0, 0.0, 0.0, 0.0, 0.09066928178071976, 0.028180083259940147, 0.0, 0.005114089697599411, 0.0, 0.0, 0.0, 0.03161918744444847, 1.1430786848068237, 0.192377507686615, 0.735931932926178, 0.046319492161273956, 0.005674184300005436, 0.22826391458511353, 0.012571459636092186, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0009567500092089176, 0.0, 0.0, 0.0, 0.0, 0.0, 0.019554294645786285, 0.0021014930680394173, 0.027322692796587944, 0.02265075594186783, 0.0, 0.0, 0.0, 0.012606753967702389, 0.0, 0.010837516747415066, 0.013739285059273243, 0.0034167009871453047, 0.015532054007053375, 0.023401489481329918, 0.0, 0.0, 0.029704250395298004, 0.0, 0.03046659752726555, 0.0, 0.0, 0.0, 0.0, 0.10730563849210739, 0.01586415432393551, 0.0, 0.049016013741493225, 0.0, 0.0, 0.011599918827414513, 0.0, 0.03908216208219528, 0.2682081162929535, 0.009148947894573212, 0.0, 0.028643546625971794, 0.0, 0.0, 0.012870891951024532, 0.04410294443368912, 1.1116923093795776, 0.13725495338439941, 0.7104324102401733, 0.07152259349822998, 0.0, 0.01418312732130289, 0.07217322289943695, 0.02536502480506897, 0.001823974191211164, 0.02182597480714321, 0.028669530525803566, 0.0, 0.0, 0.02715970389544964, 0.17785127460956573, 0.023292094469070435, 0.10456424951553345, 4.681427890318446e-05, 0.0, 0.0042351665906608105, 0.0, 0.011520817875862122, 0.0, 0.0, 0.005285928025841713, 0.010771536268293858, 0.34818902611732483, 0.0, 0.01919662393629551, 0.005992550868541002, 0.002971088979393244, 0.009224390611052513, 0.0, 0.06292682141065598, 0.037973303347826004, 0.0013872365234419703, 0.19807523488998413, 0.0, 0.014320082031190395, 0.028253652155399323, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012644179165363312, 0.04379086568951607, 0.0, 0.04035649448633194, 0.10207589715719223, 0.032959312200546265, 0.006883344613015652, 0.01945153996348381, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04932374879717827, 0.0, 0.0, 0.036410070955753326, 0.0657273605465889, 0.048203811049461365, 0.0, 0.0, 0.0, 0.014348777942359447, 0.04927179589867592, 0.0, 0.12100373953580856, 0.0, 0.0, 0.0, 0.0, 0.012134898453950882, 0.0, 0.0, 0.0, 0.009103743359446526, 0.00988683383911848, 0.0, 0.02159717120230198, 0.0, 0.0, 0.0893363282084465, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.033045656979084015, 0.0, 0.0032785034272819757, 0.0, 0.0, 0.0, 0.0, 0.0, 0.138002410531044, 0.0, 0.0031940576154738665, 0.0, 0.0, 0.0, 0.004169080872088671, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0029016700573265553, 0.05399595946073532, 0.0, 0.09555801004171371, 0.0, 0.0, 0.0, 0.0], [2.595907211303711, 1.9378843307495117, 2.035719871520996, 1.1446624994277954, 1.6176224946975708, 1.3643404245376587, 0.35979974269866943, 0.7162073254585266, 0.38016167283058167, 0.0, 0.12933509051799774, 0.21637634932994843, 0.1089577004313469, 0.09711803495883942, 0.19445432722568512, 0.29611966013908386, 0.15150940418243408, 0.17548952996730804, 0.22389698028564453, 0.15912610292434692, 0.18152767419815063, 0.03179660066962242, 0.08652324974536896, 0.19127552211284637, 0.0, 0.05417099595069885, 0.01460355520248413, 0.0, 0.0, 0.005655215121805668, 0.3141157925128937, 0.10019087046384811, 0.07040618360042572, 0.0, 0.0, 0.0, 0.06257253140211105, 0.0, 0.0, 0.0025568127166479826, 0.0, 0.0, 0.0045312391594052315, 0.0, 0.05731065571308136, 0.01520355325192213, 0.0, 0.0847330167889595, 0.03851757571101189, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015944816172122955, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03536326065659523, 0.0, 0.0, 0.0, 0.02546091005206108, 0.08975470811128616, 0.0, 0.10710959136486053, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00866493210196495, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0431026928126812, 0.0, 0.0, 0.016197293996810913, 0.0, 0.06596024334430695, 0.0, 0.0, 0.23190045356750488, 0.0, 0.010861853137612343, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08181698620319366, 0.059772927314043045, 0.0, 0.0, 0.0, 0.0, 0.01766996830701828, 0.021403701975941658, 0.0, 0.06834827363491058, 0.0, 0.015376996248960495, 0.027957944199442863, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06472546607255936, 0.07990621775388718, 0.0, 0.0, 0.0, 0.0, 0.02092008851468563, 0.20403246581554413, 0.037133410573005676, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.016197796911001205, 0.00014614210522267967, 0.0, 0.0, 0.0, 0.3803104758262634, 0.06502551585435867, 0.10625989735126495, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.031307872384786606, 0.24218598008155823, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3854040205478668, 0.05881446227431297, 0.0025817928835749626, 0.0, 0.16744554042816162, 0.0, 0.038441989570856094, 0.0, 0.0, 0.0, 0.0, 0.0, 0.022517448291182518, 0.44401705265045166, 0.0, 0.0, 0.01619844324886799, 0.0, 0.0, 0.005289264023303986, 0.0, 0.0, 0.0, 0.08074120432138443, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.022083275020122528, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009215110912919044, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005478722508996725, 0.012650678865611553, 0.0013454793952405453, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.017244787886738777, 0.020465116947889328, 0.033214010298252106, 0.021336818113923073, 0.037747789174318314, 0.024342119693756104, 0.023056888952851295, 0.0505056194961071, 0.018329201266169548, 0.01656714268028736, 0.02184993401169777, 0.0, 0.0036548369098454714, 0.030745696276426315, 0.0, 0.007415596395730972, 0.020205995067954063, 0.051703326404094696, 0.06463220715522766, 0.04481978341937065, 0.041436124593019485, 0.05730631202459335, 0.0, 0.041053593158721924, 0.09239336848258972, 0.08536255359649658, 0.07204540073871613, 0.06891833990812302, 0.11320506036281586, 0.08158528804779053, 0.06993900239467621, 0.0331270769238472, 0.10206384211778641, 0.13980922102928162, 0.0, 0.11520882695913315, 0.128508523106575, 0.03228306025266647, 0.05011283606290817, 0.07016222178936005, 0.13591288030147552, 0.1484091430902481, 0.12700192630290985, 0.14823617041110992, 0.1461714208126068, 0.033968329429626465, 0.08307994902133942, 0.16683582961559296, 0.1582074761390686, 0.14652347564697266, 0.16259492933750153, 0.09404527395963669, 0.06368379294872284, 0.04831264540553093, 0.027711696922779083, 0.15378423035144806, 0.17794527113437653, 0.08923666924238205, 0.185415118932724, 0.18198233842849731, 0.09568873047828674, 0.15145821869373322, 0.1682392656803131, 0.13229714334011078, 0.20164938271045685, 0.16122688353061676, 0.1564132273197174, 0.12252309918403625, 0.18995888531208038, 0.19300617277622223, 0.19158212840557098, 0.17245696485042572, 0.22923481464385986, 0.1540214568376541, 0.16398704051971436, 0.19637052714824677, 0.1461588442325592, 0.2093266397714615, 0.11481580883264542, 0.19924797117710114, 0.16280516982078552, 0.19772295653820038, 0.1483326554298401, 0.19560138881206512, 0.12581592798233032, 0.1588536947965622, 0.2118242383003235, 0.23024748265743256, 0.23871539533138275, 0.2320522964000702, 0.12934525310993195, 0.16032424569129944, 0.1810816526412964, 0.20644332468509674, 0.21858638525009155, 0.2645954489707947, 0.03244464099407196, 0.23557479679584503, 0.22660581767559052, 0.2396191954612732, 0.26999348402023315, 0.1956777721643448, 0.22068531811237335, 0.24286052584648132, 0.2357383370399475, 0.09044778347015381, 0.13315798342227936, 0.23730629682540894, 0.2162713259458542, 0.21904326975345612, 0.188957080245018, 0.2304035872220993, 0.23242101073265076, 0.19438520073890686, 0.22474375367164612, 0.2256222665309906, 0.261785089969635, 0.2818094789981842, 0.3042158782482147, 0.2610670030117035, 0.2682906687259674, 0.3024568259716034, 0.20963211357593536, 0.20926961302757263, 0.11303121596574783, 0.18751010298728943, 0.0896361693739891, 0.13998295366764069, 0.26363566517829895, 0.2417590469121933, 0.2549843490123749, 0.2608587443828583, 0.28729164600372314, 0.19071532785892487, 0.20181336998939514, 0.23366837203502655, 0.2775411903858185, 0.2548343241214752, 0.3277987539768219, 0.05151298642158508, 0.2822129726409912, 0.2593897879123688, 0.22507329285144806, 0.2084931880235672, 0.25466570258140564, 0.22652843594551086, 0.26174604892730713, 0.18246476352214813, 0.22690144181251526, 0.18969924747943878, 0.27619415521621704, 0.28331848978996277, 0.24491843581199646, 0.17126645147800446, 0.22639741003513336, 0.18454688787460327, 0.1916692554950714, 0.154305562376976, 0.13587823510169983, 0.05699444189667702, 0.1764651983976364, 0.07794765383005142, 0.07794765383005142], [0.0, 0.005291109438985586, 0.0, 0.018466763198375702, 0.0, 0.015011864714324474, 0.009257238358259201, 0.03713946416974068, 0.011384711600840092, 0.0, 0.019011590629816055, 0.031619854271411896, 0.008480031043291092, 0.019073620438575745, 0.7812066674232483, 0.10298940539360046, 0.11138870567083359, 0.03185460716485977, 0.028994079679250717, 0.010084019042551517, 0.024404043331742287, 0.7535995841026306, 0.03317433223128319, 0.01955188252031803, 0.0, 0.0334649495780468, 0.0069394283927977085, 0.0, 0.10883283615112305, 0.015547177754342556, 0.0, 0.0, 0.006944450084120035, 0.0, 0.0, 0.004234190098941326, 0.002699789358302951, 0.0, 3.682813257910311e-05, 0.0, 0.0, 0.053662918508052826, 0.008221916854381561, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005550316069275141, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00018578418530523777, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027262140065431595, 0.0, 0.6762374043464661, 0.03412372246384621, 0.04967325180768967, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0017578799743205309, 0.0, 0.06661318242549896, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01174260675907135, 0.000925653032027185, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.028095029294490814, 0.0, 0.0, 0.5209834575653076, 0.05119963362812996, 0.04735506698489189, 0.0, 0.0, 0.05605426803231239, 0.0, 0.007584990002214909, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08887734264135361, 0.0, 0.0, 0.0, 0.005172542296350002, 0.0, 0.0, 0.0, 0.0, 0.005852522794157267, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009429858066141605, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15010614693164825, 0.029014626517891884, 0.0, 0.0, 0.030688084661960602, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.004859644919633865, 0.12557916343212128, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08214979618787766, 0.0, 0.06622371077537537, 0.0, 0.008195638656616211, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.11127235740423203, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.8155713405576535e-05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0009048840729519725, 0.0, 0.0, 0.004220651928335428, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011368367820978165, 0.0, 0.009458649903535843, 0.0, 0.0, 0.0, 0.0, 0.00309674977324903, 0.0, 0.0, 0.002891003154218197, 0.0, 0.0, 7.367578655248508e-05, 0.0, 0.0, 0.003629951272159815, 0.05069580301642418, 0.0027389894239604473, 0.0, 0.0, 0.0, 0.003684486262500286, 0.0, 0.013768201693892479, 0.008266531862318516, 0.0022097728215157986, 0.0009644365636631846, 0.0025921144988387823, 0.0, 0.006319319363683462, 0.04127359762787819, 0.0, 0.0, 0.008320705033838749, 2.9999537218827754e-05, 0.000668183492962271, 0.016172222793102264, 0.0, 0.0, 0.0, 0.0022960794158279896, 0.0, 0.0, 0.009201213717460632, 0.0199730284512043, 0.0011568787740543485, 0.0035603917203843594, 0.01016747672110796, 0.0, 0.0, 0.0, 0.9052848815917969, 0.011460009030997753, 0.0, 0.004124484024941921, 0.0027066876646131277, 0.0046476759016513824, 0.0, 0.0005783983506262302, 0.015948867425322533, 0.0048874616622924805, 0.0002486879238858819, 0.014110347256064415, 0.0, 0.0, 0.00351703935302794, 0.0, 0.0, 0.0058375392109155655, 0.002759297378361225, 0.0, 0.0, 0.0003377238754183054, 0.005620891693979502, 0.00275009055621922, 0.00025388135691173375, 0.00276387226767838, 0.003563139121979475, 0.0, 0.0064495704136788845, 0.0, 0.00046124463551677763, 0.017108995467424393, 0.016440147534012794, 0.0, 0.0, 0.009493800811469555, 0.03946691006422043, 0.04631420224905014, 0.0019438981544226408, 0.0, 0.0, 0.0, 0.0, 0.0017340678023174405, 0.001070916187018156, 0.0016038448084145784, 0.0, 0.042059700936079025, 0.0, 0.006476738955825567, 0.0018128769006580114, 0.007206892129033804, 0.01169618871062994, 0.0, 0.0, 0.0, 0.0002248445525765419, 0.0, 0.01170420553535223, 0.0, 0.022786254063248634, 0.0, 0.8963279724121094, 0.0, 0.020871635526418686, 0.0, 0.0, 0.0, 0.018412962555885315, 0.0, 0.0, 0.015759756788611412, 0.0, 0.011058937758207321, 0.0, 0.014179104007780552, 0.0, 0.0, 0.0, 0.006753870751708746, 0.003938194364309311, 0.005901603493839502, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03541744127869606, 0.0, 0.0, 0.010003537870943546, 0.0, 0.0, 0.0, 0.0, 6.724218837916851e-05, 0.0, 0.04445821791887283, 0.005063298158347607, 0.007471319753676653, 0.0, 0.0, 0.0, 0.8808638453483582, 0.0035035591572523117, 0.0, 0.0, 0.017998304218053818, 0.0, 0.0, 0.0, 0.01185451541095972, 0.002894006669521332, 0.011959412135183811, 0.0, 0.0, 0.0213608555495739, 0.0, 0.0035573840141296387, 0.05078792944550514, 0.0023523306008428335, 0.0, 0.0, 0.002578718587756157, 0.0, 0.008543734438717365, 0.008543734438717365], [0.005428736098110676, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5018574595451355, 0.3866512179374695, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0210842527449131, 0.0, 0.04579007998108864, 0.0, 0.038782209157943726, 0.0, 0.0, 0.0, 0.0007064039818942547, 0.0, 0.0, 0.0, 0.004391210153698921, 0.0, 0.0, 0.0, 0.0, 0.049551066011190414, 0.019927462562918663, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01288054883480072, 0.0, 0.021556789055466652, 0.0, 0.4797590970993042, 0.33592307567596436, 0.0, 0.0033913482911884785, 0.06487760692834854, 0.0, 0.04283004626631737, 0.0, 0.07713650912046432, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06831517070531845, 0.0, 0.06938160210847855, 0.012836224399507046, 0.0, 0.047312621027231216, 0.06111213564872742, 0.09749961644411087, 0.0, 0.008341770619153976, 0.008547998033463955, 0.0, 0.0, 0.07154697179794312, 0.0, 0.0, 0.0, 0.014067143201828003, 0.003345523029565811, 0.008911972865462303, 0.0, 0.00296499440446496, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4838401675224304, 0.34747040271759033, 0.0, 0.0, 0.0, 0.008772953413426876, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00048755144234746695, 0.0, 0.0, 0.0, 0.003874156391248107, 0.0261597391217947, 0.0, 0.013095431961119175, 0.0, 0.0, 0.0, 0.0, 0.00441720150411129, 0.0025581505615264177, 0.0, 0.014239134266972542, 0.0, 0.010617452673614025, 0.0, 0.02575325034558773, 0.0, 0.0292839203029871, 0.0059360116720199585, 0.0, 0.0, 0.009535867720842361, 0.0, 0.027100125327706337, 0.010675131343305111, 0.0015111042885109782, 0.0, 0.010184424929320812, 0.0, 0.0, 0.0161796435713768, 0.0, 0.03047274425625801, 0.0, 0.0, 0.0, 0.014032915234565735, 0.0032640693243592978, 0.0, 0.0, 0.004979253746569157, 0.0, 0.0, 0.4689655900001526, 0.3396037518978119, 0.013275505043566227, 0.007101322524249554, 0.004195746965706348, 0.0, 0.0, 0.0, 0.023297645151615143, 0.002078681718558073, 0.012176363728940487, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.47060224413871765, 0.3481558561325073, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0003438572457525879, 0.0, 0.003613631706684828, 0.0, 0.010555988177657127, 0.0, 0.044886983931064606, 0.0, 0.00399736175313592, 0.015401238575577736, 0.006893898826092482, 0.0, 0.0, 0.0, 0.0, 0.0030313353054225445, 0.0, 0.0537688210606575, 0.0, 0.0, 0.011635602451860905, 0.009982464835047722, 0.46566683053970337, 0.46566683053970337], [0.0, 0.0, 0.0, 0.0, 0.014163140207529068, 0.06598367542028427, 0.050808895379304886, 0.1922810822725296, 0.10902854800224304, 0.0, 0.09918858110904694, 0.11811330169439316, 0.17453151941299438, 0.2103143185377121, 0.03274911269545555, 0.16680417954921722, 0.28196972608566284, 0.3866260349750519, 0.32763487100601196, 0.3087136745452881, 0.3244136571884155, 0.08951768279075623, 0.3427088260650635, 0.3597297966480255, 0.3190236985683441, 0.271253377199173, 0.3489539325237274, 0.27943065762519836, 0.34017542004585266, 0.4537905156612396, 0.349155455827713, 0.4459163248538971, 0.48447123169898987, 0.18655401468276978, 0.39716044068336487, 0.04391331225633621, 0.3772304356098175, 0.18450962007045746, 0.4434976875782013, 0.3907000720500946, 0.30412396788597107, 0.3886638581752777, 0.4559347331523895, 0.46449562907218933, 0.4541224539279938, 0.41557466983795166, 0.4574121832847595, 0.3112858235836029, 0.40860414505004883, 0.3370812237262726, 0.3890681862831116, 0.4391498267650604, 0.2089865505695343, 0.232333242893219, 0.4078175723552704, 0.38150593638420105, 0.3824344277381897, 0.4374977648258209, 0.3414730131626129, 0.4143587648868561, 0.353134423494339, 0.4150107204914093, 0.3708915412425995, 0.34575462341308594, 0.3669009208679199, 0.34981903433799744, 0.33599403500556946, 0.23792213201522827, 0.35143518447875977, 0.30442845821380615, 0.23523859679698944, 0.3067196309566498, 0.31271034479141235, 0.2421790510416031, 0.34007254242897034, 0.30039113759994507, 0.3107857406139374, 0.3715268075466156, 0.17836593091487885, 0.23839841783046722, 0.30009764432907104, 0.30326539278030396, 0.3082422614097595, 0.27586647868156433, 0.2378711700439453, 0.16583289206027985, 0.0017236779676750302, 0.1772209107875824, 0.20803618431091309, 0.27119940519332886, 0.1556272655725479, 0.21236056089401245, 0.17909793555736542, 0.0, 0.11488018929958344, 0.0, 0.1741102635860443, 0.21462099254131317, 0.18660931289196014, 0.06541186571121216, 0.12666016817092896, 0.08600973337888718, 0.07531857490539551, 0.10827968269586563, 0.19069352746009827, 0.05532582104206085, 0.07025258243083954, 0.08211551606655121, 0.06589814275503159, 0.06759146600961685, 0.0474468469619751, 0.15032346546649933, 0.13125617802143097, 0.05140487477183342, 0.15844310820102692, 0.0952090322971344, 0.03334452584385872, 0.03230193257331848, 0.12320756167173386, 0.0, 0.07516668736934662, 0.09912080317735672, 0.0, 0.0017011462477967143, 0.05564500764012337, 0.09943430870771408, 0.048134900629520416, 0.002761184936389327, 0.044952142983675, 0.005130644887685776, 0.0, 0.0, 0.0, 0.022992990911006927, 0.0, 0.0022749544586986303, 0.008178549818694592, 0.03027302958071232, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.018923195078969002, 0.0, 0.0, 0.0, 0.010218050330877304, 0.03925276920199394, 0.0, 0.015732266008853912, 0.0, 0.007658036891371012, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.055169109255075455, 0.0, 0.0, 0.0, 0.0, 0.021288320422172546, 0.0, 0.03312460333108902, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010805290192365646, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03548663109540939, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.05059892311692238, 0.010734631679952145, 0.027043279260396957, 0.4009437561035156, 0.08142036199569702, 0.25649186968803406, 0.9928380250930786, 0.5534205436706543, 0.07435233891010284, 0.07590574026107788, 0.29312488436698914, 0.041999030858278275, 0.09382178634405136, 0.09732523560523987, 0.061292488127946854, 0.06605008244514465, 0.05841846391558647, 0.045346733182668686, 0.00035906131961382926, 0.02664622850716114, 0.03005394898355007, 0.03085285611450672, 0.05207997187972069, 0.025381851941347122, 0.19046613574028015, 0.08669239282608032, 0.0421755388379097, 0.023800821974873543, 0.027102423831820488, 0.0007747889612801373, 0.28806421160697937, 0.032374221831560135, 0.021841196343302727, 0.0, 0.001923151663504541, 0.010685011744499207, 0.0022937871981412172, 0.014950137585401535, 0.0, 0.0, 0.0013516921317204833, 0.0, 0.01821609027683735, 0.0, 0.0, 0.0009199787746183574, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.016946064308285713, 0.01110603753477335, 0.0, 0.022016525268554688, 0.0, 0.002920866711065173, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0018270533764734864, 0.0, 0.0, 0.0, 0.006889814045280218, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0020797590259462595, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.048139508813619614, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13800904154777527, 0.13115639984607697, 0.0, 0.0, 0.0, 0.0, 0.16740228235721588, 0.13466466963291168, 0.002892033662647009, 0.0, 0.0, 0.0027815301436930895, 0.0, 0.10154511034488678, 0.0, 0.010643918998539448, 0.0, 0.0, 0.0002533961087465286, 0.0, 0.0, 0.0, 0.01325452420860529, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1474529504776001, 0.1217399314045906, 0.0, 0.0, 0.0, 0.0, 0.004233380313962698, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00974651426076889, 0.0, 0.0, 0.026115650311112404, 0.0, 0.0, 0.0, 0.0, 0.038614388555288315, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13059577345848083, 0.03559442237019539, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.030412547290325165, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06071775034070015, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.003619225462898612, 0.02024838700890541, 0.0, 0.04236702248454094, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0070420680567622185, 0.004991972353309393, 0.08333390206098557, 0.0, 0.0, 0.0, 0.0, 0.025249876081943512, 0.03658531978726387, 0.0, 0.0, 0.0, 0.0, 0.08803150802850723, 0.0, 0.0], [0.0, 0.0, 0.0, 0.35879427194595337, 0.0, 0.0, 0.0, 0.010202635079622269, 0.0, 0.0, 0.007235237862914801, 0.0, 0.0, 0.0, 0.0, 0.26022788882255554, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.30355700850486755, 0.0, 0.0, 0.0, 0.007486992981284857, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008005538955330849, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010596069507300854, 0.0, 0.0, 0.0, 0.0, 0.0, 0.30570513010025024, 0.0011521729175001383, 0.00043592238216660917, 0.0, 2.047704219876323e-05, 0.00039806676795706153, 0.0, 0.0, 6.922549073351547e-05, 0.0, 0.0018948616925626993, 0.0, 0.0031460938043892384, 0.0, 0.0036005955189466476, 0.0077755870297551155, 0.0008596293046139181, 0.0, 0.3493709862232208, 0.005004767794162035, 0.0030407330486923456, 0.36419764161109924, 0.0, 0.0, 0.006249171681702137, 0.008722812868654728, 0.0, 0.0, 0.007513144519180059, 0.0, 0.0, 0.006433755625039339, 0.007489701732993126, 0.0, 0.0, 0.002276333048939705, 0.007138189859688282, 0.007569366134703159, 0.2800137400627136, 0.007667870260775089, 0.005633322987705469, 0.0, 0.004546267446130514, 0.0, 0.0, 0.2915451228618622, 0.013038781471550465, 0.0012837296817451715, 0.001495632459409535, 0.003370792604982853, 0.003727282164618373, 0.005446305964142084, 0.006547422148287296, 0.00464132335036993, 0.008567853830754757, 0.0029385113157331944, 0.0, 0.0073719811625778675, 0.006920283194631338, 0.33058953285217285, 0.02129538170993328, 0.0, 0.01979239471256733, 0.0, 0.3355027139186859, 0.005112409126013517, 0.01107535045593977, 0.3305847942829132, 0.007563769351691008, 0.010378727689385414, 0.004171126056462526, 0.01399370189756155, 0.006943197455257177, 0.002528335666283965, 0.27014848589897156, 0.007330887019634247, 0.006371765863150358, 0.009840779937803745, 0.009733463637530804, 0.012877236120402813, 0.004169734660536051, 0.0, 0.005261997226625681, 0.006704504601657391, 0.0029223719611763954, 0.3220219910144806, 0.012467068620026112, 0.0002797600463964045, 0.015388433821499348, 0.006349039264023304, 0.0026187016628682613, 0.298491507768631, 0.007439806126058102, 0.0034522325731813908, 0.0009897028794512153, 0.006646553985774517, 0.0005606514750979841, 0.31702274084091187, 0.012624870054423809, 0.0, 0.006839576177299023, 0.0, 0.0009175876621156931, 0.001228612964041531, 4.276946492609568e-05, 0.0, 0.0006497383583337069, 0.001950022648088634, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014569508843123913, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008761058561503887, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007029194384813309, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0037861496675759554, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.321572870016098, 0.0, 0.0, 0.0, 0.3429504930973053, 0.0017959392862394452, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.18875528872013092, 0.0523936003446579, 0.003987619187682867, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011790307238698006, 0.0, 0.5005651712417603, 0.0, 0.5997837781906128, 0.06472817063331604, 0.009316429495811462, 0.0, 0.0, 0.0, 0.0, 0.1260053813457489, 0.08303381502628326, 0.0, 0.0, 0.006306076887995005, 0.0, 0.0801880732178688, 0.03809882327914238, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5684047341346741, 0.08182138949632645, 0.0, 0.18628858029842377, 0.0, 0.0, 0.0, 0.0, 0.2005005031824112, 0.12457044422626495, 0.0, 0.001732319942675531, 0.0, 0.014280224218964577, 0.0, 0.0, 0.0, 0.0, 0.036867327988147736, 0.03023562952876091, 0.0, 0.20639950037002563, 0.0, 0.0, 0.1821158230304718, 0.1186300739645958, 0.11267869174480438, 0.0, 0.02714068815112114, 0.1828262358903885, 0.06441016495227814, 0.9194115400314331, 0.2858636677265167, 0.011561990715563297, 0.0, 0.07059159129858017, 0.17014145851135254, 0.0, 0.0, 0.0, 0.0, 0.00476959440857172, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.002444957150146365, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13403581082820892, 0.08863533288240433, 0.31419920921325684, 0.030762454494833946, 0.638969898223877, 0.9500731825828552, 0.04386339336633682, 0.06093744933605194, 0.0, 0.03580861538648605, 0.008274040184915066, 0.0, 0.13051241636276245, 0.046340297907590866, 0.0, 0.0, 0.006927311420440674, 0.0, 0.0, 0.0, 0.0, 0.003379595000296831, 0.0, 0.0, 0.0, 0.1220165342092514, 0.09162922948598862, 0.42030051350593567, 0.005662392359226942, 0.0, 0.1612163931131363, 0.1955857276916504, 0.0, 0.38653162121772766, 0.22517047822475433, 0.01174951158463955, 0.39218300580978394, 0.0, 0.023593872785568237, 0.0, 0.09287284314632416, 0.007126497570425272, 0.474581778049469, 0.10040713846683502, 0.022460181266069412, 0.0, 0.0, 0.0, 0.0, 0.04456724971532822, 0.0, 0.0, 0.029027963057160378, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01374977920204401, 0.12713544070720673, 0.19648012518882751, 0.002867218339815736, 0.05828617513179779, 0.04620068147778511, 0.0, 0.11645318567752838, 0.029419509693980217, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012915930710732937, 0.00020832274458371103, 0.7226764559745789, 0.2793029546737671, 0.0, 0.0, 0.0, 0.05766426399350166, 0.0, 0.016718775033950806, 0.0, 0.1741473376750946, 0.19921909272670746, 0.0, 0.0, 0.019210118800401688, 0.0, 0.0, 0.0, 0.0, 0.011103138327598572, 0.0, 0.0, 0.09128879755735397, 0.0, 0.1619897335767746, 0.028356101363897324, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009897781535983086, 0.049461912363767624, 0.12553547322750092, 0.0, 0.5735105872154236, 0.86854088306427, 0.15476049482822418, 0.0, 0.0]]]})\n",
+              "            ecco.interactiveTokensAndFactorSparklines(viz_id, {'tokens': [{'token': 'هر', 'token_id': 458, 'type': 'input', 'position': 0}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 1}, {'token': ' ده', 'token_id': 546, 'type': 'input', 'position': 2}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 3}, {'token': 'ها', 'token_id': 350, 'type': 'input', 'position': 4}, {'token': ' هزار', 'token_id': 841, 'type': 'input', 'position': 5}, {'token': ' مقاله', 'token_id': 1895, 'type': 'input', 'position': 6}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 7}, {'token': ' گزارش', 'token_id': 893, 'type': 'input', 'position': 8}, {'token': ' راجع', 'token_id': 5945, 'type': 'input', 'position': 9}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 10}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 11}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 12}, {'token': ' منتشر', 'token_id': 1099, 'type': 'input', 'position': 13}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 14}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 15}, {'token': 'شود', 'token_id': 431, 'type': 'input', 'position': 16}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 17}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 18}, {'token': ' اندکی', 'token_id': 4111, 'type': 'input', 'position': 19}, {'token': ' زمان', 'token_id': 701, 'type': 'input', 'position': 20}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 21}, {'token': ' برد', 'token_id': 1981, 'type': 'input', 'position': 22}, {'token': ' تا', 'token_id': 399, 'type': 'input', 'position': 23}, {'token': ' پتانسیل', 'token_id': 6111, 'type': 'input', 'position': 24}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 25}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 26}, {'token': ' مطرح', 'token_id': 2031, 'type': 'input', 'position': 27}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 28}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 29}, {'token': ' هرکدام', 'token_id': 6242, 'type': 'input', 'position': 30}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 31}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 32}, {'token': ' مقالات', 'token_id': 5320, 'type': 'input', 'position': 33}, {'token': ' تأثیری', 'token_id': 11760, 'type': 'input', 'position': 34}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 35}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 36}, {'token': ' محسوس', 'token_id': 12950, 'type': 'input', 'position': 37}, {'token': ' بر', 'token_id': 327, 'type': 'input', 'position': 38}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 39}, {'token': ' واقعی', 'token_id': 2200, 'type': 'input', 'position': 40}, {'token': ' بگذارند', 'token_id': 6406, 'type': 'input', 'position': 41}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 42}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 43}, {'token': ' این', 'token_id': 326, 'type': 'input', 'position': 44}, {'token': ' بین', 'token_id': 619, 'type': 'input', 'position': 45}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 46}, {'token': ' بزرگترین', 'token_id': 3070, 'type': 'input', 'position': 47}, {'token': ' سرمایه', 'token_id': 1266, 'type': 'input', 'position': 48}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 49}, {'token': 'گذاران', 'token_id': 4830, 'type': 'input', 'position': 50}, {'token': ' روی', 'token_id': 539, 'type': 'input', 'position': 51}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 52}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 53}, {'token': ' یعنی', 'token_id': 1247, 'type': 'input', 'position': 54}, {'token': ' امثال', 'token_id': 13505, 'type': 'input', 'position': 55}, {'token': ' آلفابت', 'token_id': 14405, 'type': 'input', 'position': 56}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 57}, {'token': ' اپل', 'token_id': 1190, 'type': 'input', 'position': 58}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 59}, {'token': ' فیسبوک', 'token_id': 3942, 'type': 'input', 'position': 60}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 61}, {'token': ' باید', 'token_id': 544, 'type': 'input', 'position': 62}, {'token': 'وس', 'token_id': 612, 'type': 'input', 'position': 63}, {'token': ' و', 'token_id': 293, 'type': 'input', 'position': 64}, {'token': ' دیگر', 'token_id': 530, 'type': 'input', 'position': 65}, {'token': ' اسب', 'token_id': 2953, 'type': 'input', 'position': 66}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 67}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 68}, {'token': ' تک', 'token_id': 1396, 'type': 'input', 'position': 69}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 70}, {'token': 'شاخ', 'token_id': 12504, 'type': 'input', 'position': 71}, {'token': ' دنیای', 'token_id': 2112, 'type': 'input', 'position': 72}, {'token': ' تکنولوژی', 'token_id': 2061, 'type': 'input', 'position': 73}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 74}, {'token': ' بخش', 'token_id': 710, 'type': 'input', 'position': 75}, {'token': ' اعظمی', 'token_id': 15349, 'type': 'input', 'position': 76}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 77}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 78}, {'token': ' تکنولوژیک', 'token_id': 17304, 'type': 'input', 'position': 79}, {'token': ' خود', 'token_id': 377, 'type': 'input', 'position': 80}, {'token': ' را', 'token_id': 330, 'type': 'input', 'position': 81}, {'token': ' پشت', 'token_id': 1059, 'type': 'input', 'position': 82}, {'token': ' درهای', 'token_id': 10399, 'type': 'input', 'position': 83}, {'token': ' بسته', 'token_id': 1746, 'type': 'input', 'position': 84}, {'token': ' پنهان', 'token_id': 4811, 'type': 'input', 'position': 85}, {'token': ' می', 'token_id': 310, 'type': 'input', 'position': 86}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 87}, {'token': 'کنند', 'token_id': 606, 'type': 'input', 'position': 88}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 89}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 90}, {'token': ' اگر', 'token_id': 574, 'type': 'input', 'position': 91}, {'token': ' بخواهیم', 'token_id': 6385, 'type': 'input', 'position': 92}, {'token': ' واضح', 'token_id': 5272, 'type': 'input', 'position': 93}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 94}, {'token': 'تر', 'token_id': 344, 'type': 'input', 'position': 95}, {'token': ' بگوییم', 'token_id': 4676, 'type': 'input', 'position': 96}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 97}, {'token': ' وقتی', 'token_id': 1277, 'type': 'input', 'position': 98}, {'token': ' صحبت', 'token_id': 1868, 'type': 'input', 'position': 99}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 100}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 101}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 102}, {'token': ' باشد', 'token_id': 577, 'type': 'input', 'position': 103}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 104}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 105}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 106}, {'token': ' مهم', 'token_id': 871, 'type': 'input', 'position': 107}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 108}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 109}, {'token': ' دستاوردها', 'token_id': 20176, 'type': 'input', 'position': 110}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 111}, {'token': ' بازه', 'token_id': 4051, 'type': 'input', 'position': 112}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 113}, {'token': 'ای', 'token_id': 289, 'type': 'input', 'position': 114}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 115}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 116}, {'token': 'ساله', 'token_id': 6857, 'type': 'input', 'position': 117}, {'token': ' کاری', 'token_id': 1379, 'type': 'input', 'position': 118}, {'token': ' آسان', 'token_id': 3109, 'type': 'input', 'position': 119}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 120}, {'token': ' حساب', 'token_id': 1650, 'type': 'input', 'position': 121}, {'token': ' نمی', 'token_id': 624, 'type': 'input', 'position': 122}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 123}, {'token': 'آید', 'token_id': 1721, 'type': 'input', 'position': 124}, {'token': '؛', 'token_id': 556, 'type': 'input', 'position': 125}, {'token': ' حداقل', 'token_id': 2235, 'type': 'input', 'position': 126}, {'token': ' نه', 'token_id': 995, 'type': 'input', 'position': 127}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 128}, {'token': ' آسانی', 'token_id': 7654, 'type': 'input', 'position': 129}, {'token': ' لیست', 'token_id': 2740, 'type': 'input', 'position': 130}, {'token': ' کردن', 'token_id': 714, 'type': 'input', 'position': 131}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 132}, {'token': ' موبایل', 'token_id': 1532, 'type': 'input', 'position': 133}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 134}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 135}, {'token': ' پرچمدار', 'token_id': 4810, 'type': 'input', 'position': 136}, {'token': ' یا', 'token_id': 421, 'type': 'input', 'position': 137}, {'token': ' بهترین', 'token_id': 1142, 'type': 'input', 'position': 138}, {'token': ' ویژگی', 'token_id': 1413, 'type': 'input', 'position': 139}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 140}, {'token': 'های', 'token_id': 325, 'type': 'input', 'position': 141}, {'token': ' اضافه', 'token_id': 1469, 'type': 'input', 'position': 142}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 143}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 144}, {'token': ' تازه', 'token_id': 1903, 'type': 'input', 'position': 145}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 146}, {'token': 'ترین', 'token_id': 496, 'type': 'input', 'position': 147}, {'token': ' ورژن', 'token_id': 10005, 'type': 'input', 'position': 148}, {'token': ' از', 'token_id': 312, 'type': 'input', 'position': 149}, {'token': ' iOS', 'token_id': 3658, 'type': 'input', 'position': 150}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 151}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 152}, {'token': ' اما', 'token_id': 492, 'type': 'input', 'position': 153}, {'token': ' هرطور', 'token_id': 39899, 'type': 'input', 'position': 154}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 155}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 156}, {'token': ' موضوع', 'token_id': 964, 'type': 'input', 'position': 157}, {'token': ' نگاه', 'token_id': 1624, 'type': 'input', 'position': 158}, {'token': ' کنیم', 'token_id': 1085, 'type': 'input', 'position': 159}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 160}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 161}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 162}, {'token': ' بدون', 'token_id': 1042, 'type': 'input', 'position': 163}, {'token': ' تردید', 'token_id': 6746, 'type': 'input', 'position': 164}, {'token': ' نقشی', 'token_id': 6806, 'type': 'input', 'position': 165}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 166}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 167}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 168}, {'token': ' ۲۰۲۰', 'token_id': 3668, 'type': 'input', 'position': 169}, {'token': ' میلادی', 'token_id': 1547, 'type': 'input', 'position': 170}, {'token': ' ایفا', 'token_id': 4912, 'type': 'input', 'position': 171}, {'token': ' کرده', 'token_id': 501, 'type': 'input', 'position': 172}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 173}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 174}, {'token': ' بنابراین', 'token_id': 1504, 'type': 'input', 'position': 175}, {'token': ' بیایید', 'token_id': 7496, 'type': 'input', 'position': 176}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 177}, {'token': ' مرور', 'token_id': 2550, 'type': 'input', 'position': 178}, {'token': ' شش', 'token_id': 2606, 'type': 'input', 'position': 179}, {'token': ' دستاورد', 'token_id': 8149, 'type': 'input', 'position': 180}, {'token': ' بزرگ', 'token_id': 745, 'type': 'input', 'position': 181}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 182}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'input', 'position': 183}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 184}, {'token': ' سالی', 'token_id': 4029, 'type': 'input', 'position': 185}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 186}, {'token': ' اکنون', 'token_id': 1801, 'type': 'input', 'position': 187}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 188}, {'token': ' روزهای', 'token_id': 2897, 'type': 'input', 'position': 189}, {'token': ' آخرش', 'token_id': 16847, 'type': 'input', 'position': 190}, {'token': ' نزدیک', 'token_id': 1460, 'type': 'input', 'position': 191}, {'token': ' شده', 'token_id': 401, 'type': 'input', 'position': 192}, {'token': ' بپردازیم', 'token_id': 7984, 'type': 'input', 'position': 193}, {'token': '.', 'token_id': 24, 'type': 'input', 'position': 194}, {'token': ' ', 'token_id': 231, 'type': 'input', 'position': 195}, {'token': ' در', 'token_id': 298, 'type': 'input', 'position': 196}, {'token': ' یک', 'token_id': 367, 'type': 'input', 'position': 197}, {'token': ' سال', 'token_id': 415, 'type': 'input', 'position': 198}, {'token': ' معمولی', 'token_id': 3350, 'type': 'input', 'position': 199}, {'token': '،', 'token_id': 305, 'type': 'input', 'position': 200}, {'token': ' ابزاری', 'token_id': 6048, 'type': 'input', 'position': 201}, {'token': ' که', 'token_id': 323, 'type': 'input', 'position': 202}, {'token': ' کارش', 'token_id': 6853, 'type': 'input', 'position': 203}, {'token': ' تولید', 'token_id': 667, 'type': 'input', 'position': 204}, {'token': ' متن', 'token_id': 1555, 'type': 'input', 'position': 205}, {'token': ' است', 'token_id': 329, 'type': 'input', 'position': 206}, {'token': ' به', 'token_id': 303, 'type': 'input', 'position': 207}, {'token': ' هیچ', 'token_id': 917, 'type': 'input', 'position': 208}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 209}, {'token': 'وجه', 'token_id': 8362, 'type': 'input', 'position': 210}, {'token': ' جزء', 'token_id': 5953, 'type': 'input', 'position': 211}, {'token': ' هیجان', 'token_id': 3814, 'type': 'input', 'position': 212}, {'token': '\\u200c', 'token_id': 285, 'type': 'input', 'position': 213}, {'token': 'انگیزترین', 'token_id': 20502, 'type': 'input', 'position': 214}, {'token': ' دستاوردهای', 'token_id': 7442, 'type': 'input', 'position': 215}, {'token': ' حوزه', 'token_id': 1403, 'type': 'input', 'position': 216}, {'token': ' هوش', 'token_id': 976, 'type': 'input', 'position': 217}, {'token': ' مصنوعی', 'token_id': 2734, 'type': 'output', 'position': 218}], 'factors': [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.005007287487387657, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.09339607506990433, 0.0, 0.0, 0.010801723226904869, 0.0, 0.0, 0.0, 0.0, 0.0906691700220108, 0.02818000689148903, 0.0, 0.005114074796438217, 0.0, 0.0, 0.0, 0.031619224697351456, 1.1430772542953491, 0.19237737357616425, 0.7359310984611511, 0.04631945863366127, 0.005674276500940323, 0.22826378047466278, 0.012571458704769611, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0009568047244101763, 0.0, 0.0, 0.0, 0.0, 0.0, 0.019554195925593376, 0.0021015158854424953, 0.02732272259891033, 0.022650770843029022, 0.0, 0.0, 0.0, 0.012606726959347725, 0.0, 0.010837499052286148, 0.013739313930273056, 0.003416723106056452, 0.015532031655311584, 0.02340151183307171, 0.0, 0.0, 0.029704267159104347, 0.0, 0.030466632917523384, 0.0, 0.0, 0.0, 0.0, 0.10730555653572083, 0.01586415432393551, 0.0, 0.04901597648859024, 0.0, 0.0, 0.011599970050156116, 0.0, 0.03908218815922737, 0.26820796728134155, 0.009148968383669853, 0.0, 0.028643542900681496, 0.0, 0.0, 0.012870898470282555, 0.04410294443368912, 1.1116913557052612, 0.13725480437278748, 0.7104313969612122, 0.07152257859706879, 0.0, 0.014183206483721733, 0.07217329740524292, 0.025365004315972328, 0.0018240262288600206, 0.02182593196630478, 0.028669554740190506, 0.0, 0.0, 0.027159620076417923, 0.1778510957956314, 0.0232920553535223, 0.10456389933824539, 4.681363861891441e-05, 0.0, 0.004235119093209505, 0.0, 0.011520828120410442, 0.0, 0.0, 0.005285968538373709, 0.010771578177809715, 0.3481888175010681, 0.0, 0.019196635112166405, 0.005992497783154249, 0.0029711229726672173, 0.009224400855600834, 0.0, 0.06292672455310822, 0.0379733107984066, 0.0013872672570869327, 0.19807492196559906, 0.0, 0.014319909736514091, 0.02825356274843216, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012644050642848015, 0.043790727853775024, 0.0, 0.040356412529945374, 0.10207583755254745, 0.032959308475255966, 0.006883346009999514, 0.01945153996348381, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0493236668407917, 0.0, 0.0, 0.036410022526979446, 0.06572728604078293, 0.048203784972429276, 0.0, 0.0, 0.0, 0.014348767697811127, 0.04927171394228935, 0.0, 0.12100362777709961, 0.0, 0.0, 0.0, 0.0, 0.012134944088757038, 0.0, 0.0, 0.0, 0.009103773161768913, 0.009886815212666988, 0.0, 0.02159709669649601, 0.0, 0.0, 0.08933624625205994, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03304554149508476, 0.0, 0.003278537420555949, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1380022168159485, 0.0, 0.003194074612110853, 0.0, 0.0, 0.0, 0.004169052466750145, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0029016155749559402, 0.05399586632847786, 0.0, 0.09555776417255402, 0.0, 0.0, 0.0, 0.0], [2.5959043502807617, 1.937880039215088, 2.0357143878936768, 1.1446596384048462, 1.6176177263259888, 1.3643373250961304, 0.3597990870475769, 0.7162058353424072, 0.38016122579574585, 0.0, 0.12933525443077087, 0.21637585759162903, 0.10895742475986481, 0.09711795300245285, 0.19445358216762543, 0.2961193323135376, 0.15150903165340424, 0.17548924684524536, 0.22389669716358185, 0.15912571549415588, 0.18152731657028198, 0.031796444207429886, 0.08652320504188538, 0.19127531349658966, 0.0, 0.054171137511730194, 0.014603444375097752, 0.0, 0.0, 0.005655359476804733, 0.3141154646873474, 0.100190669298172, 0.07040639221668243, 0.0, 0.0, 0.0, 0.06257244944572449, 0.0, 0.0, 0.0025570301804691553, 0.0, 0.0, 0.004531326703727245, 0.0, 0.05731064826250076, 0.015203702263534069, 0.0, 0.08473286032676697, 0.03851750120520592, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.015944741666316986, 0.0, 0.0, 0.0, 0.0, 0.0, 0.035363294184207916, 0.0, 0.0, 0.0, 0.025460850447416306, 0.08975453674793243, 0.0, 0.10710945725440979, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008664947003126144, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.043102651834487915, 0.0, 0.0, 0.016197199001908302, 0.0, 0.06595995277166367, 0.0, 0.0, 0.23190009593963623, 0.0, 0.010861773043870926, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08181692659854889, 0.05977282673120499, 0.0, 0.0, 0.0, 0.0, 0.01766984537243843, 0.021403653547167778, 0.0, 0.06834806501865387, 0.0, 0.015377005562186241, 0.02795781008899212, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06472520530223846, 0.07990599423646927, 0.0, 0.0, 0.0, 0.0, 0.020920127630233765, 0.20403237640857697, 0.037133391946554184, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01619775965809822, 0.000146107588079758, 0.0, 0.0, 0.0, 0.3803093731403351, 0.06502535939216614, 0.10625965148210526, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.031307775527238846, 0.24218527972698212, 0.0, 0.0, 0.0, 0.0, 0.0, 0.38540321588516235, 0.05881422013044357, 0.0025817446876317263, 0.0, 0.16744530200958252, 0.0, 0.03844192251563072, 0.0, 0.0, 0.0, 0.0, 0.0, 0.022517431527376175, 0.44401606917381287, 0.0, 0.0, 0.01619838923215866, 0.0, 0.0, 0.005289252381771803, 0.0, 0.0, 0.0, 0.08074113726615906, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.022083239629864693, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009215058758854866, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0054787821136415005, 0.012650711461901665, 0.0013454712461680174, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.017244715243577957, 0.020465144887566566, 0.033213987946510315, 0.02133682370185852, 0.037747737020254135, 0.024342142045497894, 0.023056861013174057, 0.05050559714436531, 0.018329231068491936, 0.016567161306738853, 0.021849926561117172, 0.0, 0.003654847154393792, 0.030745649710297585, 0.0, 0.0074156057089567184, 0.02020597830414772, 0.05170334875583649, 0.06463220715522766, 0.04481977969408035, 0.041436079889535904, 0.057306256145238876, 0.0, 0.041053492575883865, 0.09239332377910614, 0.0853625237941742, 0.07204537093639374, 0.06891822814941406, 0.11320501565933228, 0.08158519119024277, 0.06993898749351501, 0.033127106726169586, 0.10206381231546402, 0.13980907201766968, 0.0, 0.11520878970623016, 0.12850841879844666, 0.03228302299976349, 0.050112802535295486, 0.07016224414110184, 0.13591280579566956, 0.14840908348560333, 0.1270017772912979, 0.14823605120182037, 0.14617131650447845, 0.03396836295723915, 0.08307993412017822, 0.16683581471443176, 0.15820740163326263, 0.14652326703071594, 0.16259488463401794, 0.09404516965150833, 0.06368373334407806, 0.048312582075595856, 0.027711665257811546, 0.15378421545028687, 0.1779450625181198, 0.08923671394586563, 0.18541496992111206, 0.18198232352733612, 0.09568873047828674, 0.15145814418792725, 0.16823922097682953, 0.13229714334011078, 0.20164935290813446, 0.1612267643213272, 0.1564132571220398, 0.12252297252416611, 0.18995875120162964, 0.19300617277622223, 0.19158197939395905, 0.17245681583881378, 0.2292347252368927, 0.15402144193649292, 0.16398684680461884, 0.19637033343315125, 0.14615871012210846, 0.20932641625404358, 0.11481574177742004, 0.19924789667129517, 0.16280503571033478, 0.1977229118347168, 0.14833250641822815, 0.1956012099981308, 0.12581586837768555, 0.15885362029075623, 0.21182416379451752, 0.2302474081516266, 0.23871535062789917, 0.23205217719078064, 0.12934520840644836, 0.16032402217388153, 0.181081622838974, 0.2064431607723236, 0.21858632564544678, 0.26459529995918274, 0.032444603741168976, 0.2355746477842331, 0.22660569846630096, 0.2396191656589508, 0.2699933350086212, 0.1956777423620224, 0.2206851691007614, 0.24286045134067535, 0.23573826253414154, 0.09044769406318665, 0.13315804302692413, 0.23730629682540894, 0.21627113223075867, 0.2190432846546173, 0.18895697593688965, 0.2304033637046814, 0.23242083191871643, 0.1943851262331009, 0.2247435599565506, 0.22562216222286224, 0.26178500056266785, 0.2818094789981842, 0.304215669631958, 0.2610667645931244, 0.268290638923645, 0.302456796169281, 0.2096320241689682, 0.20926958322525024, 0.11303102225065231, 0.1875099539756775, 0.08963620662689209, 0.13998286426067352, 0.263635516166687, 0.24175894260406494, 0.2549843490123749, 0.2608586251735687, 0.2872915267944336, 0.1907152682542801, 0.20181326568126678, 0.2336682677268982, 0.2775411307811737, 0.25483426451683044, 0.3277985751628876, 0.05151303857564926, 0.2822128236293793, 0.25938963890075684, 0.22507336735725403, 0.20849309861660004, 0.2546655833721161, 0.2265283316373825, 0.2617459297180176, 0.1824646145105362, 0.22690141201019287, 0.18969914317131042, 0.27619418501853943, 0.28331831097602844, 0.24491840600967407, 0.17126646637916565, 0.22639727592468262, 0.1845468282699585, 0.19166921079158783, 0.15430548787117004, 0.1358780413866043, 0.056994352489709854, 0.17646510899066925, 0.07794767618179321, 0.07794767618179321], [0.0, 0.0052911024540662766, 0.0, 0.018466776236891747, 0.0, 0.015011944808065891, 0.009257295168936253, 0.03713953122496605, 0.011384748853743076, 0.0, 0.01901172660291195, 0.03161995857954025, 0.008480054326355457, 0.019073640927672386, 0.7812086939811707, 0.10298974066972733, 0.11138911545276642, 0.03185466676950455, 0.028994141146540642, 0.010084040462970734, 0.024404097348451614, 0.7536020874977112, 0.03317444771528244, 0.019551964476704597, 0.0, 0.03346503525972366, 0.006939451210200787, 0.0, 0.1088331863284111, 0.015547201968729496, 0.0, 0.0, 0.006944471038877964, 0.0, 0.0, 0.004234256222844124, 0.0026997763197869062, 0.0, 3.6832469049841166e-05, 0.0, 0.0, 0.05366313457489014, 0.008221914991736412, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0055503519251942635, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0001857944153016433, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.027262205258011818, 0.0, 0.6762396097183228, 0.034123823046684265, 0.0496734194457531, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.001757888589054346, 0.0, 0.06661340594291687, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011742684990167618, 0.0009256743942387402, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.028095128014683723, 0.0, 0.0, 0.5209852457046509, 0.0511997826397419, 0.04735521227121353, 0.0, 0.0, 0.05605442449450493, 0.0, 0.007585021201521158, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08887764811515808, 0.0, 0.0, 0.0, 0.005172568839043379, 0.0, 0.0, 0.0, 0.0, 0.005852502770721912, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00942990928888321, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15010663866996765, 0.02901470847427845, 0.0, 0.0, 0.030688168480992317, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0048596239648759365, 0.12557964026927948, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.08215003460645676, 0.0, 0.06622397154569626, 0.0, 0.00819567870348692, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.11127229779958725, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.8155878933612257e-05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0009049036889337003, 0.0, 0.0, 0.0042206114158034325, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.011368412524461746, 0.0, 0.009458668529987335, 0.0, 0.0, 0.0, 0.0, 0.0030967507045716047, 0.0, 0.0, 0.002891004551202059, 0.0, 0.0, 7.369260129053146e-05, 0.0, 0.0, 0.0036299540661275387, 0.05069584399461746, 0.0027389926835894585, 0.0, 0.0, 0.0, 0.003684503026306629, 0.0, 0.013768213801085949, 0.008266528137028217, 0.002209773752838373, 0.0009644373203627765, 0.0025921338237822056, 0.0, 0.006319334730505943, 0.041273631155490875, 0.0, 0.0, 0.008320719003677368, 3.0005083317519166e-05, 0.0006681827362626791, 0.01617223024368286, 0.0, 0.0, 0.0, 0.0022960733622312546, 0.0, 0.0, 0.009201223962008953, 0.019973013550043106, 0.0011568859918043017, 0.0035603889264166355, 0.010167503729462624, 0.0, 0.0, 0.0, 0.9052853584289551, 0.011460022069513798, 0.0, 0.004124482162296772, 0.002706688828766346, 0.004647670779377222, 0.0, 0.0005784117383882403, 0.015948865562677383, 0.004887464921921492, 0.0002486936573404819, 0.014110377989709377, 0.0, 0.0, 0.0035170495975762606, 0.0, 0.0, 0.005837567150592804, 0.002759296679869294, 0.0, 0.0, 0.0003377212560735643, 0.005620909389108419, 0.002750098006799817, 0.0002538972767069936, 0.0027638643514364958, 0.003563135862350464, 0.0, 0.006449556443840265, 0.0, 0.00046124550863169134, 0.01710900478065014, 0.01644013449549675, 0.0, 0.0, 0.009493800811469555, 0.03946690633893013, 0.04631423205137253, 0.0019438863964751363, 0.0, 0.0, 0.0, 0.0, 0.0017340794438496232, 0.0010709253838285804, 0.0016038494650274515, 0.0, 0.04205971956253052, 0.0, 0.006476755253970623, 0.0018128848168998957, 0.0072068884037435055, 0.011696198023855686, 0.0, 0.0, 0.0, 0.0002248441887786612, 0.0, 0.011704197153449059, 0.0, 0.02278624102473259, 0.0, 0.8963283896446228, 0.0, 0.020871585234999657, 0.0, 0.0, 0.0, 0.018412956967949867, 0.0, 0.0, 0.015759779140353203, 0.0, 0.011058919131755829, 0.0, 0.014179090037941933, 0.0, 0.0, 0.0, 0.006753868889063597, 0.003938192967325449, 0.005901613272726536, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03541744500398636, 0.0, 0.0, 0.010003534145653248, 0.0, 0.0, 0.0, 0.0, 6.722722173435614e-05, 0.0, 0.04445820301771164, 0.005063293501734734, 0.007471315562725067, 0.0, 0.0, 0.0, 0.8808642625808716, 0.0035035505425184965, 0.0, 0.0, 0.017998315393924713, 0.0, 0.0, 0.0, 0.011854510754346848, 0.002893989672884345, 0.011959427036345005, 0.0, 0.0, 0.021360840648412704, 0.0, 0.003557375865057111, 0.05078795179724693, 0.002352332230657339, 0.0, 0.0, 0.0025786971673369408, 0.0, 0.008543732576072216, 0.008543732576072216], [0.00542871467769146, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5018573999404907, 0.38665109872817993, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.021084262058138847, 0.0, 0.04579010605812073, 0.0, 0.03878220170736313, 0.0, 0.0, 0.0, 0.0007064035162329674, 0.0, 0.0, 0.0, 0.004391190595924854, 0.0, 0.0, 0.0, 0.0, 0.04955107718706131, 0.019927438348531723, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012880559079349041, 0.0, 0.021556738764047623, 0.0, 0.47975921630859375, 0.33592307567596436, 0.0, 0.0033913450315594673, 0.06487762928009033, 0.0, 0.04283005744218826, 0.0, 0.07713652402162552, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06831517070531845, 0.0, 0.06938164681196213, 0.012836230918765068, 0.0, 0.047312602400779724, 0.061112165451049805, 0.09749960899353027, 0.0, 0.008341758511960506, 0.008548004552721977, 0.0, 0.0, 0.07154697179794312, 0.0, 0.0, 0.0, 0.014067159034311771, 0.0033455120865255594, 0.0089119803160429, 0.0, 0.0029650006908923388, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4838404953479767, 0.34747031331062317, 0.0, 0.0, 0.0, 0.008772936649620533, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0004875561862718314, 0.0, 0.0, 0.0, 0.0038741561584174633, 0.026159722357988358, 0.0, 0.013095429167151451, 0.0, 0.0, 0.0, 0.0, 0.004417189862579107, 0.0025581433437764645, 0.0, 0.014239111915230751, 0.0, 0.010617430321872234, 0.0, 0.025753265246748924, 0.0, 0.029283953830599785, 0.005936015862971544, 0.0, 0.0, 0.009535875171422958, 0.0, 0.027100136503577232, 0.01067512296140194, 0.0015110837994143367, 0.0, 0.010184411890804768, 0.0, 0.0, 0.01617962121963501, 0.0, 0.030472738668322563, 0.0, 0.0, 0.0, 0.01403291430324316, 0.003264068625867367, 0.0, 0.0, 0.004979245364665985, 0.0, 0.0, 0.46896564960479736, 0.3396035432815552, 0.01327548734843731, 0.007101306691765785, 0.004195741377770901, 0.0, 0.0, 0.0, 0.02329764887690544, 0.00207869173027575, 0.012176379561424255, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.47060221433639526, 0.34815579652786255, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00034382575540803373, 0.0, 0.003613617504015565, 0.0, 0.010555983521044254, 0.0, 0.044886987656354904, 0.0, 0.003997367806732655, 0.015401240438222885, 0.006893901154398918, 0.0, 0.0, 0.0, 0.0, 0.0030313259921967983, 0.0, 0.0537688173353672, 0.0, 0.0, 0.011635622009634972, 0.009982476010918617, 0.465666800737381, 0.465666800737381], [0.0, 0.0, 0.0, 0.0, 0.01416334230452776, 0.06598351150751114, 0.05080896615982056, 0.1922810822725296, 0.1090286448597908, 0.0, 0.09918856620788574, 0.11811339110136032, 0.1745315045118332, 0.21031442284584045, 0.03274935111403465, 0.16680391132831573, 0.28196993470191956, 0.3866259753704071, 0.32763490080833435, 0.3087137043476105, 0.32441356778144836, 0.08951745927333832, 0.34270861744880676, 0.35972973704338074, 0.3190239667892456, 0.2712531089782715, 0.34895405173301697, 0.27943068742752075, 0.3401755690574646, 0.4537903070449829, 0.34915536642074585, 0.4459162950515747, 0.4844711124897003, 0.18655410408973694, 0.3971606194972992, 0.0439133383333683, 0.37723034620285034, 0.18450962007045746, 0.44349735975265503, 0.39069968461990356, 0.30412375926971436, 0.38866350054740906, 0.45593467354774475, 0.46449539065361023, 0.4541223347187042, 0.4155746400356293, 0.4574122428894043, 0.3112855851650238, 0.4086039066314697, 0.3370812237262726, 0.3890680968761444, 0.4391495883464813, 0.20898640155792236, 0.232333242893219, 0.4078173041343689, 0.3815060555934906, 0.3824346959590912, 0.4374975562095642, 0.3414730131626129, 0.4143586754798889, 0.35313448309898376, 0.41501060128211975, 0.3708915114402771, 0.3457544445991516, 0.3669007420539856, 0.34981897473335266, 0.3359939157962799, 0.23792192339897156, 0.3514351546764374, 0.3044285774230957, 0.23523861169815063, 0.3067193627357483, 0.3127102851867676, 0.24217897653579712, 0.3400726020336151, 0.3003910183906555, 0.3107854723930359, 0.37152668833732605, 0.17836594581604004, 0.23839865624904633, 0.3000974655151367, 0.30326539278030396, 0.30824217200279236, 0.2758665680885315, 0.23787112534046173, 0.16583286225795746, 0.00172354094684124, 0.17722082138061523, 0.2080361247062683, 0.27119937539100647, 0.15562714636325836, 0.21236054599285126, 0.17909792065620422, 0.0, 0.11488009989261627, 0.0, 0.17411023378372192, 0.21462099254131317, 0.18660931289196014, 0.0654117688536644, 0.12666012346744537, 0.08600958436727524, 0.07531850785017014, 0.1082795113325119, 0.19069354236125946, 0.055325496941804886, 0.07025203853845596, 0.08211544901132584, 0.06589800119400024, 0.06759130209684372, 0.047446925193071365, 0.1503233015537262, 0.1312560737133026, 0.051404692232608795, 0.15844304859638214, 0.09520888328552246, 0.033344294875860214, 0.03230181336402893, 0.12320756912231445, 0.0, 0.07516662031412125, 0.0991206020116806, 0.0, 0.0017010344890877604, 0.05564502999186516, 0.09943424165248871, 0.04813477396965027, 0.00276109017431736, 0.04495212435722351, 0.005130653735250235, 0.0, 0.0, 0.0, 0.022993087768554688, 0.0, 0.002274926984682679, 0.008178594522178173, 0.03027302213013172, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.018923167139291763, 0.0, 0.0, 0.0, 0.01021801121532917, 0.03925279900431633, 0.0, 0.015732312574982643, 0.0, 0.00765801640227437, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.05516916885972023, 0.0, 0.0, 0.0, 0.0, 0.021288394927978516, 0.0, 0.0331246517598629, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010805293917655945, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.035486627370119095, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0505988709628582, 0.01073465682566166, 0.027043262496590614, 0.40094316005706787, 0.08142013847827911, 0.2564915716648102, 0.9928369522094727, 0.5534198880195618, 0.07435216009616852, 0.07590563595294952, 0.2931244969367981, 0.04199889302253723, 0.09382162988185883, 0.09732499718666077, 0.06129232048988342, 0.06604987382888794, 0.058418359607458115, 0.0453466922044754, 0.0003590703709051013, 0.026646187528967857, 0.03005385585129261, 0.030852654948830605, 0.052079781889915466, 0.02538173273205757, 0.19046597182750702, 0.08669222146272659, 0.04217549040913582, 0.02380080707371235, 0.027102353051304817, 0.0007747014751657844, 0.2880639135837555, 0.032374121248722076, 0.021841170266270638, 0.0, 0.0019230460748076439, 0.010684938170015812, 0.002293702680617571, 0.01495006587356329, 0.0, 0.0, 0.0013516376493498683, 0.0, 0.018216103315353394, 0.0, 0.0, 0.0009199150372296572, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.016946017742156982, 0.011105942539870739, 0.0, 0.02201644703745842, 0.0, 0.0029207763727754354, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0018270808504894376, 0.0, 0.0, 0.0, 0.006889731623232365, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0020797536708414555, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.048139460384845734, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1380089670419693, 0.13115628063678741, 0.0, 0.0, 0.0, 0.0, 0.16740283370018005, 0.13466528058052063, 0.002892045071348548, 0.0, 0.0, 0.0027815140783786774, 0.0, 0.10154522955417633, 0.0, 0.010644066147506237, 0.0, 0.0, 0.0002533754741307348, 0.0, 0.0, 0.0, 0.013254603371024132, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1474534124135971, 0.12174038589000702, 0.0, 0.0, 0.0, 0.0, 0.004233366809785366, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009746523573994637, 0.0, 0.0, 0.02611553855240345, 0.0, 0.0, 0.0, 0.0, 0.03861437737941742, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1305955946445465, 0.035594392567873, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.03041248209774494, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06071779131889343, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.003619193332269788, 0.020248372107744217, 0.0, 0.04236692935228348, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007042048964649439, 0.004991969559341669, 0.08333393186330795, 0.0, 0.0, 0.0, 0.0, 0.025249840691685677, 0.03658537566661835, 0.0, 0.0, 0.0, 0.0, 0.08803142607212067, 0.0, 0.0], [0.0, 0.0, 0.0, 0.3587944507598877, 0.0, 0.0, 0.0, 0.010202649980783463, 0.0, 0.0, 0.007235249038785696, 0.0, 0.0, 0.0, 0.0, 0.26022812724113464, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3035571277141571, 0.0, 0.0, 0.0, 0.007487005088478327, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008005569688975811, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.010596094653010368, 0.0, 0.0, 0.0, 0.0, 0.0, 0.30570530891418457, 0.0011521816486492753, 0.00043593437294475734, 0.0, 2.0477062207646668e-05, 0.0003980710171163082, 0.0, 0.0, 6.922556349309161e-05, 0.0, 0.0018948481883853674, 0.0, 0.0031461042817682028, 0.0, 0.003600610652938485, 0.007775594945997, 0.0008596357074566185, 0.0, 0.349371075630188, 0.00500477384775877, 0.0030407262966036797, 0.36419785022735596, 0.0, 0.0, 0.006249179132282734, 0.008722797967493534, 0.0, 0.0, 0.007513144519180059, 0.0, 0.0, 0.006433766335248947, 0.007489699404686689, 0.0, 0.0, 0.002276343060657382, 0.007138204760849476, 0.007569370325654745, 0.28001394867897034, 0.00766787538304925, 0.005633334629237652, 0.0, 0.004546272102743387, 0.0, 0.0, 0.29154521226882935, 0.013038793578743935, 0.001283734804019332, 0.0014956281520426273, 0.0033708037808537483, 0.003727296367287636, 0.005446316674351692, 0.006547426804900169, 0.004641330800950527, 0.008567854762077332, 0.002938516205176711, 0.0, 0.007372002582997084, 0.006920280400663614, 0.3305896520614624, 0.021295396611094475, 0.0, 0.019792431965470314, 0.0, 0.3355028033256531, 0.005112431012094021, 0.011075364425778389, 0.33058494329452515, 0.007563777267932892, 0.010378736071288586, 0.004171120934188366, 0.013993707485496998, 0.006943203508853912, 0.002528319600969553, 0.2701486051082611, 0.007330881431698799, 0.006371764466166496, 0.009840777143836021, 0.009733463637530804, 0.012877237051725388, 0.004169738385826349, 0.0, 0.005262003280222416, 0.006704513914883137, 0.0029223833698779345, 0.3220219314098358, 0.012467085383832455, 0.00027976412093266845, 0.015388439409434795, 0.0063490308821201324, 0.002618730068206787, 0.298491895198822, 0.00743979774415493, 0.003452251199632883, 0.0009896897245198488, 0.006646550726145506, 0.0005606594495475292, 0.3170228600502014, 0.012624870054423809, 0.0, 0.006839571986347437, 0.0, 0.0009175876621156931, 0.0012286180863156915, 4.275970422895625e-05, 0.0, 0.0006497314316220582, 0.001950009143911302, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.014569510705769062, 0.0, 0.0, 0.0, 0.0, 0.0, 0.008761044591665268, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.007029208354651928, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0037861536256968975, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3215729892253876, 0.0, 0.0, 0.0, 0.3429504334926605, 0.0017959148390218616, 0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.1887553334236145, 0.05239385366439819, 0.003987486939877272, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01179030817002058, 0.0, 0.5005649924278259, 0.0, 0.5997835397720337, 0.06472811847925186, 0.009316381067037582, 0.0, 0.0, 0.0, 0.0, 0.12600521743297577, 0.0830337405204773, 0.0, 0.0, 0.006306111812591553, 0.0, 0.08018805831670761, 0.0380987785756588, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5684053897857666, 0.08182141184806824, 0.0, 0.18628853559494019, 0.0, 0.0, 0.0, 0.0, 0.20050068199634552, 0.12457054853439331, 0.0, 0.0017323587089776993, 0.0, 0.014280208386480808, 0.0, 0.0, 0.0, 0.0, 0.036867398768663406, 0.030235541984438896, 0.0, 0.20639945566654205, 0.0, 0.0, 0.18211589753627777, 0.11863002926111221, 0.11267874389886856, 0.0, 0.02714073285460472, 0.18282657861709595, 0.06441029906272888, 0.9194111824035645, 0.2858636975288391, 0.011561946012079716, 0.0, 0.07059158384799957, 0.17014136910438538, 0.0, 0.0, 0.0, 0.0, 0.004769692663103342, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0024449650663882494, 0.0, 0.0, 0.0, 0.0, 0.0, 0.13403597474098206, 0.08863569051027298, 0.3141995072364807, 0.030762529000639915, 0.6389704346656799, 0.9500727653503418, 0.043863482773303986, 0.0609375461935997, 0.0, 0.035808708518743515, 0.008274128660559654, 0.0, 0.13051240146160126, 0.04634033516049385, 0.0, 0.0, 0.006927362643182278, 0.0, 0.0, 0.0, 0.0, 0.003379654372110963, 0.0, 0.0, 0.0, 0.12201663106679916, 0.0916295051574707, 0.4203011989593506, 0.005662483163177967, 0.0, 0.16121655702590942, 0.19558586180210114, 0.0, 0.38653188943862915, 0.2251707911491394, 0.011749522760510445, 0.39218348264694214, 0.0, 0.023593924939632416, 0.0, 0.0928729847073555, 0.007126547396183014, 0.4745825231075287, 0.1004072055220604, 0.022460274398326874, 0.0, 0.0, 0.0, 0.0, 0.044567257165908813, 0.0, 0.0, 0.029027948155999184, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.013749770820140839, 0.12713530659675598, 0.19648030400276184, 0.0028672320768237114, 0.05828620120882988, 0.04620068892836571, 0.0, 0.11645320057868958, 0.029419517144560814, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012915940023958683, 0.0002083152940031141, 0.7226763367652893, 0.27930310368537903, 0.0, 0.0, 0.0, 0.05766427516937256, 0.0, 0.01671871729195118, 0.0, 0.1741473525762558, 0.19921909272670746, 0.0, 0.0, 0.019210031256079674, 0.0, 0.0, 0.0, 0.0, 0.0111031299456954, 0.0, 0.0, 0.09128888696432114, 0.0, 0.16198959946632385, 0.028356077149510384, 0.0, 0.0, 0.0, 0.0, 0.0, 0.009897695854306221, 0.04946191981434822, 0.1255355179309845, 0.0, 0.5735112428665161, 0.8685407042503357, 0.15476049482822418, 0.0, 0.0]]]})\n",
               "         }, function (err) {\n",
               "            console.log(err);\n",
               "        })"
@@ -3119,7 +5392,7 @@
       "source": [
         ""
       ],
-      "execution_count": null,
+      "execution_count": 17,
       "outputs": []
     }
   ]


### PR DESCRIPTION
I found that bug #3 is by Ecco. The Ecco doesn't cover other gpt2 models in the current version. I suggested a temporary way to handle this inconsistency.

Now you can clone the [notebook](https://colab.research.google.com/github/hooshvare/parsgpt/blob/master/notebooks/Persian_GPT2_Visualization.ipynb) on your Colab. Let me know if the issue is fixed!